### PR TITLE
为 QGBot 增加直接获取 `channel` 的能力和直接向指定 `channel` 发送消息的能力

### DIFF
--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/QQGuildApiException.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/QQGuildApiException.kt
@@ -69,8 +69,8 @@ public fun QQGuildApiException.copyCurrent(): QQGuildApiException = addStackTrac
  * @suppress internal API to add suppressed for api exception
  */
 @InternalApi
-public inline fun <E : QQGuildApiException> E.addStackTrace(name: String? = null): E {
-    addSuppressed(APIStackException(name))
+public inline fun <E : QQGuildApiException> E.addStackTrace(block: () -> String? = { null }): E {
+    addSuppressed(APIStackException(block()))
     return this
 }
 

--- a/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/QGBot.kt
+++ b/simbot-component-qq-guild-core-common/src/main/kotlin/love/forte/simbot/component/qguild/QGBot.kt
@@ -17,16 +17,22 @@
 
 package love.forte.simbot.component.qguild
 
+import io.ktor.client.*
+import io.ktor.client.request.*
 import kotlinx.coroutines.isActive
 import love.forte.simbot.ID
 import love.forte.simbot.action.UnsupportedActionException
 import love.forte.simbot.bot.Bot
+import love.forte.simbot.component.qguild.message.QGMessageReceipt
 import love.forte.simbot.definition.Contact
 import love.forte.simbot.definition.Group
 import love.forte.simbot.definition.GuildBot
 import love.forte.simbot.event.EventProcessor
 import love.forte.simbot.message.Image
+import love.forte.simbot.message.Message
+import love.forte.simbot.message.MessageContent
 import love.forte.simbot.qguild.QQGuildApiException
+import love.forte.simbot.qguild.api.MessageAuditedException
 import love.forte.simbot.qguild.model.ChannelType
 import love.forte.simbot.utils.item.Items
 import love.forte.simbot.utils.item.Items.Companion.emptyItems
@@ -211,6 +217,65 @@ public interface QGBot : Bot {
      */
     @JST(blockingBaseName = "getCategory", blockingSuffix = "", asyncBaseName = "getCategory")
     public suspend fun category(channelId: ID): QGChannelCategory?
+
+
+    /**
+     * 直接向目标子频道发送消息。
+     *
+     * 此频道需要为文字子频道，否则会产生异常，但是此异常不会由程序检测，
+     * 而是通过API的错误响应 [QQGuildApiException] 体现。
+     *
+     * [sendTo] 相对于 [QGChannel.send] 而言更加“不可靠”
+     * —— 因为它跳过了对频道服务器和对子频道类型的校验，失去了在消息中自动填充 `msgId` 等透明行为，并且直接使用ID也会存在一些细微的隐患。
+     * 但是这可以有效规避当没有获取频道服务器或子频道信息权限时候可能导致的问题。
+     *
+     * @throws Exception see [HttpClient.request], 可能会抛出任何ktor请求过程中的异常。
+     * @throws QQGuildApiException 请求异常，例如无权限
+     * @throws MessageAuditedException 当响应状态为表示消息审核的 `304023`、`304024` 时
+     *
+     * @return 消息发送回执
+     */
+    @JST
+    public suspend fun sendTo(channelId: ID, text: String): QGMessageReceipt
+
+    /**
+     * 直接向目标子频道发送消息。
+     *
+     * 此频道需要为文字子频道，否则会产生异常，但是此异常不会由程序检测，
+     * 而是通过API的错误响应 [QQGuildApiException] 体现。
+     *
+     * [sendTo] 相对于 [QGChannel.send] 而言更加“不可靠”
+     * —— 因为它跳过了对频道服务器和对子频道类型的校验，失去了在消息中自动填充 `msgId` 等透明行为，并且直接使用ID也会存在一些细微的隐患。
+     * 但是这可以有效规避当没有获取频道服务器或子频道信息权限时候可能导致的问题。
+     *
+     * @throws Exception see [HttpClient.request], 可能会抛出任何ktor请求过程中的异常。
+     * @throws QQGuildApiException 请求异常，例如无权限
+     * @throws MessageAuditedException 当响应状态为表示消息审核的 `304023`、`304024` 时
+     *
+     * @return 消息发送回执
+     */
+    @JST
+    public suspend fun sendTo(channelId: ID, message: Message): QGMessageReceipt
+
+    /**
+     * 直接向目标子频道发送消息。
+     *
+     * 此频道需要为文字子频道，否则会产生异常，但是此异常不会由程序检测，
+     * 而是通过API的错误响应 [QQGuildApiException] 体现。
+     *
+     * [sendTo] 相对于 [QGChannel.send] 而言更加“不可靠”
+     * —— 因为它跳过了对频道服务器和对子频道类型的校验，失去了在消息中自动填充 `msgId` 等透明行为，并且直接使用ID也会存在一些细微的隐患。
+     * 但是这可以有效规避当没有获取频道服务器或子频道信息权限时候可能导致的问题。
+     *
+     * @throws Exception see [HttpClient.request], 可能会抛出任何ktor请求过程中的异常。
+     * @throws QQGuildApiException 请求异常，例如无权限
+     * @throws MessageAuditedException 当响应状态为表示消息审核的 `304023`、`304024` 时
+     *
+     * @return 消息发送回执
+     */
+    @JST
+    public suspend fun sendTo(channelId: ID, message: MessageContent): QGMessageReceipt
+
 
     /**
      * Deprecated: QQ频道BOT不存在'联系人'列表，始终得到 [emptyItems]。

--- a/simbot-component-qq-guild-core/build.gradle.kts
+++ b/simbot-component-qq-guild-core/build.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
     sourceSets.configureEach {
         languageSettings {
             optIn("love.forte.simbot.InternalSimbotApi")
+            optIn("love.forte.simbot.qguild.InternalApi")
         }
     }
 }

--- a/simbot-component-qq-guild-core/src/main/kotlin/love/forte/simbot/component/qguild/internal/QGBotImpl.kt
+++ b/simbot-component-qq-guild-core/src/main/kotlin/love/forte/simbot/component/qguild/internal/QGBotImpl.kt
@@ -28,10 +28,14 @@ import love.forte.simbot.component.qguild.event.QGBotStartedEvent
 import love.forte.simbot.component.qguild.internal.QGGuildImpl.Companion.qgGuild
 import love.forte.simbot.component.qguild.internal.event.QGBotStartedEventImpl
 import love.forte.simbot.component.qguild.internal.forum.QGForumChannelImpl
+import love.forte.simbot.component.qguild.message.QGMessageReceipt
+import love.forte.simbot.component.qguild.message.sendMessage
 import love.forte.simbot.component.qguild.util.requestBy
 import love.forte.simbot.event.EventProcessor
 import love.forte.simbot.literal
 import love.forte.simbot.logger.LoggerFactory
+import love.forte.simbot.message.Message
+import love.forte.simbot.message.MessageContent
 import love.forte.simbot.qguild.*
 import love.forte.simbot.qguild.DisposableHandle
 import love.forte.simbot.qguild.api.channel.GetChannelApi
@@ -247,6 +251,30 @@ internal class QGBotImpl(
                 )
             }
 
+        }
+    }
+
+    override suspend fun sendTo(channelId: ID, text: String): QGMessageReceipt {
+        return try {
+            bot.sendMessage(channelId.literal, text)
+        } catch (e: QQGuildApiException) {
+            throw e.addStackTrace { "Bot.sendTo" }
+        }
+    }
+
+    override suspend fun sendTo(channelId: ID, message: Message): QGMessageReceipt {
+        return try {
+            bot.sendMessage(channelId.literal, message)
+        } catch (e: QQGuildApiException) {
+            throw e.addStackTrace { "Bot.sendTo" }
+        }
+    }
+
+    override suspend fun sendTo(channelId: ID, message: MessageContent): QGMessageReceipt {
+        return try {
+            bot.sendMessage(channelId.literal, message)
+        } catch (e: QQGuildApiException) {
+            throw e.addStackTrace { "Bot.sendTo" }
         }
     }
 

--- a/simbot-component-qq-guild-core/src/main/kotlin/love/forte/simbot/component/qguild/internal/QGGuildBotImpl.kt
+++ b/simbot-component-qq-guild-core/src/main/kotlin/love/forte/simbot/component/qguild/internal/QGGuildBotImpl.kt
@@ -19,10 +19,13 @@ package love.forte.simbot.component.qguild.internal
 
 import love.forte.simbot.ID
 import love.forte.simbot.component.qguild.*
+import love.forte.simbot.component.qguild.message.QGMessageReceipt
 import love.forte.simbot.component.qguild.util.requestBy
 import love.forte.simbot.event.EventProcessor
 import love.forte.simbot.literal
 import love.forte.simbot.message.Image
+import love.forte.simbot.message.Message
+import love.forte.simbot.message.MessageContent
 import love.forte.simbot.qguild.Bot
 import love.forte.simbot.qguild.QQGuildApiException
 import love.forte.simbot.qguild.api.member.GetMemberApi
@@ -90,6 +93,12 @@ internal class QGGuildBotImpl(
     override suspend fun channel(channelId: ID): QGChannel? = bot.channel(channelId)
 
     override suspend fun category(channelId: ID): QGChannelCategory? = bot.category(channelId)
+
+    override suspend fun sendTo(channelId: ID, text: String): QGMessageReceipt = bot.sendTo(channelId, text)
+
+    override suspend fun sendTo(channelId: ID, message: Message): QGMessageReceipt = bot.sendTo(channelId, message)
+
+    override suspend fun sendTo(channelId: ID, message: MessageContent): QGMessageReceipt = bot.sendTo(channelId, message)
 
     override fun toString(): String {
         return "QGGuildBotImpl(bot=$bot, guildId=$guildId)"

--- a/simbot-component-qq-guild-core/src/main/kotlin/love/forte/simbot/component/qguild/internal/QGMemberImpl.kt
+++ b/simbot-component-qq-guild-core/src/main/kotlin/love/forte/simbot/component/qguild/internal/QGMemberImpl.kt
@@ -151,7 +151,7 @@ internal class QGMemberImpl(
                 DmsSendApi.create(dms.guildId, it.build()).requestBy(bot)
             }.asReceipt()
         } catch (e: QQGuildApiException) {
-            throw e.addStackTrace("member.send")
+            throw e.addStackTrace { "member.send" }
         }
     }
 

--- a/simbot-component-qq-guild-core/src/main/kotlin/love/forte/simbot/component/qguild/internal/QGTextChannelImpl.kt
+++ b/simbot-component-qq-guild-core/src/main/kotlin/love/forte/simbot/component/qguild/internal/QGTextChannelImpl.kt
@@ -73,7 +73,7 @@ internal class QGTextChannelImpl internal constructor(
                 }
             }
         } catch (e: QQGuildApiException) {
-            throw e.addStackTrace("channel.send")
+            throw e.addStackTrace { "channel.send" }
         }
     }
 
@@ -86,7 +86,7 @@ internal class QGTextChannelImpl internal constructor(
                 }
             }
         } catch (e: QQGuildApiException) {
-            throw e.addStackTrace("channel.send")
+            throw e.addStackTrace { "channel.send" }
         }
     }
 
@@ -99,7 +99,7 @@ internal class QGTextChannelImpl internal constructor(
                 }
             }
         } catch (e: QQGuildApiException) {
-            throw e.addStackTrace("channel.send")
+            throw e.addStackTrace { "channel.send" }
         }
     }
 

--- a/simbot-component-qq-guild-core/src/main/kotlin/love/forte/simbot/component/qguild/internal/message/QGReceiveMessageContentImpl.kt
+++ b/simbot-component-qq-guild-core/src/main/kotlin/love/forte/simbot/component/qguild/internal/message/QGReceiveMessageContentImpl.kt
@@ -29,7 +29,7 @@ import love.forte.simbot.qguild.model.Message
  */
 internal class QGReceiveMessageContentImpl(override val sourceMessage: Message) : QGReceiveMessageContent() {
 
-    override val messageId: ID = sourceMessage.id.ID
+    override val messageId: ID get() = sourceMessage.id.ID
 
     private val parseContext by lazy(LazyThreadSafetyMode.PUBLICATION) { MessageParsers.parse(sourceMessage) }
 

--- a/simbot-component-qq-guild-core/src/main/kotlin/love/forte/simbot/component/qguild/message/MessageSender.kt
+++ b/simbot-component-qq-guild-core/src/main/kotlin/love/forte/simbot/component/qguild/message/MessageSender.kt
@@ -24,6 +24,7 @@ import love.forte.simbot.component.qguild.util.requestBy
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.MessageContent
 import love.forte.simbot.qguild.QQGuildApiException
+import love.forte.simbot.qguild.api.MessageAuditedException
 import love.forte.simbot.qguild.api.message.MessageSendApi
 import love.forte.simbot.qguild.api.message.direct.DmsSendApi
 import love.forte.simbot.qguild.message.ContentTextEncoder
@@ -46,6 +47,7 @@ import love.forte.simbot.qguild.message.ContentTextEncoder
  * @see MessageParsers.parse
  *
  * @throws QQGuildApiException 请求得到了异常的结果
+ * @throws MessageAuditedException 当响应状态为表示消息审核的 `304023`、`304024` 时
  *
  * @return 发送后的回执
  */
@@ -85,6 +87,7 @@ public suspend inline fun QGBot.sendMessage(
  * @see MessageParsers.parse
  *
  * @throws QQGuildApiException 请求得到了异常的结果
+ * @throws MessageAuditedException 当响应状态为表示消息审核的 `304023`、`304024` 时
  *
  * @return 发送后的回执
  */
@@ -125,6 +128,7 @@ public suspend inline fun QGBot.sendMessage(
  * @see QGContentText
  *
  * @throws QQGuildApiException 请求得到了异常的结果
+ * @throws MessageAuditedException 当响应状态为表示消息审核的 `304023`、`304024` 时
  *
  * @return 发送后的回执
  */


### PR DESCRIPTION
```kotlin
val bot: QGBot = ...

// 直接获取channel或category
val channel: QGChannel? = bot.channel(123.ID)
val category: QGChannelCategory? = bot.category(123.ID)

// 直接发送消息
bot.sendTo(123.ID, "text message")
bot.sendTo(123.ID, message)
bot.sendTo(123.ID, messageContent)
```

> **Note**:
> 当使用 `sendTo` 时，你需要自行处理 `msgId` 的填充，比如拼接使用 `QGReplyTo`


close #93