### PR TITLE
refactor(model): 为数据类添加 @ApiModelConstructor 注解，并调整相关配置以支持注解使用

### DIFF
--- a/simbot-component-qq-guild-api/api/simbot-component-qq-guild-api.api
+++ b/simbot-component-qq-guild-api/api/simbot-component-qq-guild-api.api
@@ -1,6 +1,9 @@
 public abstract interface annotation class love/forte/simbot/qguild/ApiModel : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class love/forte/simbot/qguild/ApiModelConstructor : java/lang/annotation/Annotation {
+}
+
 public final class love/forte/simbot/qguild/ErrInfo {
 	public static final field Companion Llove/forte/simbot/qguild/ErrInfo$Companion;
 	public fun <init> (ILjava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
@@ -5646,8 +5649,6 @@ public synthetic class love/forte/simbot/qguild/model/MessageKeyboard$$serialize
 public final class love/forte/simbot/qguild/model/MessageKeyboard$Action {
 	public static final field Companion Llove/forte/simbot/qguild/model/MessageKeyboard$Action$Companion;
 	public fun <init> (Llove/forte/simbot/qguild/model/MessageKeyboard$ActionPermission;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;)V
-	public fun <init> (Llove/forte/simbot/qguild/model/MessageKeyboard$ActionPermission;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;I)V
-	public synthetic fun <init> (Llove/forte/simbot/qguild/model/MessageKeyboard$ActionPermission;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Llove/forte/simbot/qguild/model/MessageKeyboard$ActionPermission;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Llove/forte/simbot/qguild/model/MessageKeyboard$ActionPermission;
 	public final fun component2 ()Ljava/lang/String;
@@ -5657,8 +5658,6 @@ public final class love/forte/simbot/qguild/model/MessageKeyboard$Action {
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()I
 	public final fun copy (Llove/forte/simbot/qguild/model/MessageKeyboard$ActionPermission;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;)Llove/forte/simbot/qguild/model/MessageKeyboard$Action;
-	public final fun copy (Llove/forte/simbot/qguild/model/MessageKeyboard$ActionPermission;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;I)Llove/forte/simbot/qguild/model/MessageKeyboard$Action;
-	public static synthetic fun copy$default (Llove/forte/simbot/qguild/model/MessageKeyboard$Action;Llove/forte/simbot/qguild/model/MessageKeyboard$ActionPermission;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;IILjava/lang/Object;)Llove/forte/simbot/qguild/model/MessageKeyboard$Action;
 	public static synthetic fun copy$default (Llove/forte/simbot/qguild/model/MessageKeyboard$Action;Llove/forte/simbot/qguild/model/MessageKeyboard$ActionPermission;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/qguild/model/MessageKeyboard$Action;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAnchor ()Ljava/lang/Integer;

--- a/simbot-component-qq-guild-api/build.gradle.kts
+++ b/simbot-component-qq-guild-api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -42,7 +42,10 @@ kotlin {
 
     compilerOptions {
         freeCompilerArgs.add("-Xexpect-actual-classes")
-        optIn.add("love.forte.simbot.qguild.QGInternalApi")
+        optIn.addAll(
+            "love.forte.simbot.qguild.QGInternalApi",
+            "love.forte.simbot.qguild.ApiModelConstructor",
+        )
     }
 
     configKotlinJvm()

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/annotations.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/annotations.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -32,6 +32,23 @@ package love.forte.simbot.qguild
 @Retention(AnnotationRetention.SOURCE)
 @MustBeDocumented
 public annotation class ApiModel
+
+/**
+ * 被标记了 [ApiModel] 的数据载体类型的构造函数（以及数据类生成的解构函数、copy 函数），
+ * 为了确保兼容性 **不应** 被直接调用。
+ * 在后续版本和 5.0 版本之后，它们会被过渡为隐藏了构造的数据类或普通类型。
+ *
+ * @since 4.2.3
+ */
+@RequiresOptIn(
+    message = "被标记了 `@ApiModel` 的数据载体类型的构造函数（以及解构函数、copy 函数），" +
+            "为了确保兼容性 **不应** 被直接调用。" +
+            "在后续版本和 5.0 版本之后，它们会被过渡为隐藏了构造的数据类或普通类型。"
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CONSTRUCTOR)
+@MustBeDocumented
+public annotation class ApiModelConstructor
 
 /**
  * 标记一个API类型，代表它是一个在QQ频道API文档中被标记 **仅支持私域机器人** 的API。

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/MessageAuditedException.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/MessageAuditedException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -20,6 +20,7 @@ package love.forte.simbot.qguild.api
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 import love.forte.simbot.qguild.ErrInfo
 import love.forte.simbot.qguild.QGInternalApi
 import love.forte.simbot.qguild.QQGuildApiException
@@ -112,4 +113,4 @@ internal data class MessageAudit(@SerialName("message_audit") val messageAudit: 
  */
 @ApiModel
 @Serializable
-public data class MessageAuditedId(@SerialName("audit_id") val auditId: String)
+public data class MessageAuditedId @ApiModelConstructor constructor(@SerialName("audit_id") val auditId: String)

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/app/GetAppAccessTokenApi.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/app/GetAppAccessTokenApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024. ForteScarlet.
+ * Copyright (c) 2024-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -22,6 +22,7 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 import love.forte.simbot.qguild.api.PostQQGuildApi
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
@@ -83,7 +84,7 @@ public class GetAppAccessTokenApi private constructor(
  */
 @ApiModel
 @Serializable
-public data class AppAccessToken(
+public data class AppAccessToken @ApiModelConstructor constructor(
     @SerialName("access_token")
     val accessToken: String,
     @SerialName("expires_in")

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/forum/GetThreadListApi.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/forum/GetThreadListApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -21,6 +21,7 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 import love.forte.simbot.qguild.PrivateDomainOnly
 import love.forte.simbot.qguild.api.GetQQGuildApi
 import love.forte.simbot.qguild.api.NumberAsBooleanSerializer
@@ -61,7 +62,7 @@ public class GetThreadListApi private constructor(channelId: String) : GetQQGuil
  */
 @ApiModel
 @Serializable
-public data class ThreadListResult(
+public data class ThreadListResult @ApiModelConstructor constructor(
     /**
      * 帖子列表对象（返回值里面的content字段，可参照RichText结构）
      */

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/forum/PublishThreadApi.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/forum/PublishThreadApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -21,8 +21,10 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 import love.forte.simbot.qguild.api.PutQQGuildApi
 import love.forte.simbot.qguild.api.SimplePutApiDescription
+import love.forte.simbot.qguild.api.forum.PublishThreadApi.Factory.create
 import kotlin.jvm.JvmStatic
 
 /**
@@ -171,7 +173,7 @@ public enum class ThreadPublishFormat(public val value: Int) {
  */
 @ApiModel
 @Serializable
-public data class ThreadPublishResult(
+public data class ThreadPublishResult @ApiModelConstructor constructor(
     @SerialName("task_id") val taskId: String,
     @SerialName("create_time") val createTime: String
 )

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/guild/mute/MuteMultiMemberApi.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/guild/mute/MuteMultiMemberApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -22,6 +22,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.common.time.TimeUnit
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 import love.forte.simbot.qguild.api.PatchQQGuildApi
 import love.forte.simbot.qguild.api.SimplePatchApiDescription
 import kotlin.jvm.JvmStatic
@@ -99,4 +100,4 @@ public class MuteMultiMemberApi private constructor(guildId: String, private val
  */
 @ApiModel
 @Serializable
-public data class MultiMuteResult(@SerialName("user_ids") val userIds: List<String>)
+public data class MultiMuteResult @ApiModelConstructor constructor(@SerialName("user_ids") val userIds: List<String>)

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/member/GetGuildRoleMemberListApi.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/member/GetGuildRoleMemberListApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -25,6 +25,7 @@ import kotlinx.serialization.Serializable
 import love.forte.simbot.logger.LoggerFactory
 import love.forte.simbot.logger.logger
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 import love.forte.simbot.qguild.PrivateDomainOnly
 import love.forte.simbot.qguild.api.GetQQGuildApi
 import love.forte.simbot.qguild.api.SimpleGetApiDescription
@@ -109,7 +110,7 @@ public class GetGuildRoleMemberListApi private constructor(
  */
 @ApiModel
 @Serializable
-public data class GuildRoleMemberList(
+public data class GuildRoleMemberList @ApiModelConstructor constructor(
     /**
      * 一组用户信息对象
      */

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/role/CreateGuildRoleApi.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/role/CreateGuildRoleApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024. ForteScarlet.
+ * Copyright (c) 2022-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -21,6 +21,7 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 import love.forte.simbot.qguild.api.PostQQGuildApi
 import love.forte.simbot.qguild.api.SimplePostApiDescription
 import love.forte.simbot.qguild.model.ColorIntSerializer
@@ -93,7 +94,7 @@ public class CreateGuildRoleApi private constructor(
  */
 @ApiModel
 @Serializable
-public data class GuildRoleCreated(
+public data class GuildRoleCreated @ApiModelConstructor constructor(
     /**
      * 身份组 ID
      */

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/role/GetGuildRoleListApi.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/role/GetGuildRoleListApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024. ForteScarlet.
+ * Copyright (c) 2022-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -21,6 +21,7 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 import love.forte.simbot.qguild.api.GetQQGuildApi
 import love.forte.simbot.qguild.api.SimpleGetApiDescription
 import love.forte.simbot.qguild.model.Role
@@ -57,7 +58,7 @@ public class GetGuildRoleListApi private constructor(guildId: String) : GetQQGui
  */
 @ApiModel
 @Serializable
-public data class GuildRoleList(
+public data class GuildRoleList @ApiModelConstructor constructor(
     /**
      * 频道 ID
      */

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/event/channels.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/event/channels.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -20,6 +20,7 @@ package love.forte.simbot.qguild.event
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 import love.forte.simbot.qguild.model.Channel
 import love.forte.simbot.qguild.model.ChannelSubType
 import love.forte.simbot.qguild.model.ChannelType
@@ -93,7 +94,7 @@ public data class ChannelDelete(
  */
 @ApiModel
 @Serializable
-public data class EventChannel(
+public data class EventChannel @ApiModelConstructor constructor(
     /** 子频道 id */
     val id: String,
     /** 频道 id */

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/event/guilds.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/event/guilds.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -20,6 +20,7 @@ package love.forte.simbot.qguild.event
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 import love.forte.simbot.qguild.model.Guild
 
 /**
@@ -93,7 +94,7 @@ public data class GuildDelete(
  */
 @ApiModel
 @Serializable
-public data class EventGuild(
+public data class EventGuild @ApiModelConstructor constructor(
     /** 频道ID */
     override val id: String,
     /** 频道名称 */

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/event/members.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/event/members.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -20,6 +20,7 @@ package love.forte.simbot.qguild.event
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 import love.forte.simbot.qguild.model.MemberWithGuildId
 import love.forte.simbot.qguild.model.User
 import love.forte.simbot.qguild.time.ZERO_ISO_INSTANT
@@ -74,7 +75,7 @@ public data class GuildMemberRemove(
  */
 @ApiModel
 @Serializable
-public data class EventMember(
+public data class EventMember @ApiModelConstructor constructor(
     /**
      * 频道id
      */

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/event/openForums.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/event/openForums.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -20,6 +20,7 @@ package love.forte.simbot.qguild.event
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 import love.forte.simbot.qguild.model.forum.ForumSourceInfo
 
 /**
@@ -165,7 +166,7 @@ public data class OpenForumThreadDelete(
  */
 @Serializable
 @ApiModel
-public data class OpenForumThreadData(
+public data class OpenForumThreadData @ApiModelConstructor constructor(
     @SerialName("guild_id") override val guildId: String,
     @SerialName("channel_id") override val channelId: String,
     @SerialName("author_id") override val authorId: String,
@@ -221,7 +222,7 @@ public data class OpenForumPostDelete(
  */
 @Serializable
 @ApiModel
-public data class OpenForumPostData(
+public data class OpenForumPostData @ApiModelConstructor constructor(
     @SerialName("guild_id") override val guildId: String,
     @SerialName("channel_id") override val channelId: String,
     @SerialName("author_id") override val authorId: String,
@@ -276,7 +277,7 @@ public data class OpenForumReplyDelete(
  */
 @Serializable
 @ApiModel
-public data class OpenForumReplyData(
+public data class OpenForumReplyData @ApiModelConstructor constructor(
     @SerialName("guild_id") override val guildId: String,
     @SerialName("channel_id") override val channelId: String,
     @SerialName("author_id") override val authorId: String,

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/Announces.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/Announces.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -20,6 +20,7 @@ package love.forte.simbot.qguild.model
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 import love.forte.simbot.qguild.QGApi4J
 import kotlin.jvm.JvmName
 
@@ -29,7 +30,7 @@ import kotlin.jvm.JvmName
  */
 @ApiModel
 @Serializable
-public data class Announces(
+public data class Announces @ApiModelConstructor constructor(
     /** 频道 id */
     @SerialName("guild_id") val guildId: String,
     /** 子频道 id */
@@ -58,7 +59,7 @@ public data class Announces(
  */
 @ApiModel
 @Serializable
-public data class RecommendChannel(
+public data class RecommendChannel @ApiModelConstructor constructor(
     /** 子频道 id */
     @SerialName("channel_id") val channelId: String,
     /** 推荐语 */

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/ApiPermission.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/ApiPermission.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -20,6 +20,7 @@ package love.forte.simbot.qguild.model
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 import love.forte.simbot.qguild.api.ApiDescription
 import kotlin.jvm.JvmName
 import kotlin.jvm.JvmStatic
@@ -30,7 +31,7 @@ import kotlin.jvm.JvmStatic
  */
 @ApiModel
 @Serializable
-public data class ApiPermission(
+public data class ApiPermission @ApiModelConstructor constructor(
     /**
      * API 接口名，例如 `/guilds/{guild_id}/members/{user_id}`
      */
@@ -69,7 +70,7 @@ public inline val ApiPermission.isAuthorized: Boolean
  */
 @ApiModel
 @Serializable
-public data class ApiPermissionDemand(
+public data class ApiPermissionDemand @ApiModelConstructor constructor(
     /**
      * 申请接口权限的频道 id
      */

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/Channel.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/Channel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -26,6 +26,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.JvmSynthetic
@@ -101,7 +102,7 @@ public interface Channel : Comparable<Channel> {
  */
 @ApiModel
 @Serializable
-public data class SimpleChannel(
+public data class SimpleChannel @ApiModelConstructor constructor(
     /** 子频道 id */
     override val id: String,
     /** 频道 id */

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/ChannelPermissions.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/ChannelPermissions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -20,6 +20,7 @@ package love.forte.simbot.qguild.model
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 import kotlin.jvm.JvmName
 
 /**
@@ -28,7 +29,7 @@ import kotlin.jvm.JvmName
  */
 @ApiModel
 @Serializable
-public data class ChannelPermissions(
+public data class ChannelPermissions @ApiModelConstructor constructor(
     /**
      * 子频道 id
      */

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/Guild.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/Guild.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -20,6 +20,7 @@ package love.forte.simbot.qguild.model
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 
 /**
  *
@@ -62,7 +63,7 @@ public interface Guild {
  */
 @ApiModel
 @Serializable
-public data class SimpleGuild(
+public data class SimpleGuild @ApiModelConstructor constructor(
     /** 频道ID */
     override val id: String,
     /** 频道名称 */

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/Member.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/Member.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -20,6 +20,7 @@ package love.forte.simbot.qguild.model
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 import love.forte.simbot.qguild.time.ZERO_ISO_INSTANT
 
 /**
@@ -70,7 +71,7 @@ public interface MemberWithGuildId : Member {
  */
 @ApiModel
 @Serializable
-public data class SimpleMember(
+public data class SimpleMember @ApiModelConstructor constructor(
     /**
      * 用户的频道基础信息，只有成员相关接口中会填充此信息
      */
@@ -96,7 +97,7 @@ public data class SimpleMember(
  */
 @ApiModel
 @Serializable
-public data class SimpleMemberWithGuildId(
+public data class SimpleMemberWithGuildId @ApiModelConstructor constructor(
 
     /**
      * 频道id

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/Message.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/Message.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025. ForteScarlet.
+ * Copyright (c) 2022-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -24,6 +24,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 import love.forte.simbot.qguild.message.EmbedBuilder
 import love.forte.simbot.qguild.time.ZERO_ISO_INSTANT
 import kotlin.jvm.JvmOverloads
@@ -38,7 +39,7 @@ import kotlin.jvm.JvmSynthetic
  */
 @ApiModel
 @Serializable
-public data class Message(
+public data class Message @ApiModelConstructor constructor(
     /**
      * 消息 id
      */
@@ -457,7 +458,7 @@ public data class Message(
  */
 @ApiModel
 @Serializable
-public data class MessageMember(
+public data class MessageMember @ApiModelConstructor constructor(
     override val nick: String = "",
     override val roles: List<String> = emptyList(),
     @SerialName("joined_at")

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/MessageKeyboard.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/MessageKeyboard.kt
@@ -20,6 +20,7 @@ package love.forte.simbot.qguild.model
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 import love.forte.simbot.qguild.QQGuild
 import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
@@ -32,7 +33,7 @@ import kotlin.jvm.JvmStatic
  */
 @ApiModel
 @Serializable
-public data class MessageKeyboard(
+public data class MessageKeyboard @ApiModelConstructor constructor(
     /**
      * 按钮ID：在一个 keyboard 消息内设置唯一
      */
@@ -76,7 +77,7 @@ public data class MessageKeyboard(
      */
     @ApiModel
     @Serializable
-    public data class RenderData(
+    public data class RenderData @ApiModelConstructor constructor(
         /**
          * 	按钮上的文字
          */
@@ -97,7 +98,7 @@ public data class MessageKeyboard(
      */
     @ApiModel
     @Serializable
-    public data class ActionPermission(
+    public data class ActionPermission @ApiModelConstructor constructor(
         /**
          * 0 指定用户可操作，1 仅管理者可操作，2 所有人可操作，3 指定身份组可操作（仅频道可用）
          */
@@ -118,9 +119,10 @@ public data class MessageKeyboard(
      * [MessageKeyboard.action].
      * 参考 [官方文档](https://bot.q.qq.com/wiki/develop/api-v2/server-inter/message/trans/msg-btn.html)
      */
+    @ConsistentCopyVisibility
     @ApiModel
     @Serializable
-    public data class Action(
+    public data class Action @ApiModelConstructor internal constructor(
         val permission: ActionPermission? = null,
         /**
          * 操作相关的数据
@@ -159,6 +161,7 @@ public data class MessageKeyboard(
          * 4.2.2 版本以前作为主构造使用，现在用作兼容性辅助构造。
          * 为了兼容，`type` 属性默认为 `2`。
          */
+        @ApiModelConstructor
         public constructor(
             permission: ActionPermission? = null,
             data: String?,

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/MessageMedia.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/MessageMedia.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024. ForteScarlet.
+ * Copyright (c) 2024-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -20,6 +20,7 @@ package love.forte.simbot.qguild.model
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 
 
 /**
@@ -34,7 +35,7 @@ import love.forte.simbot.qguild.ApiModel
  */
 @ApiModel
 @Serializable
-public data class MessageMedia(
+public data class MessageMedia @ApiModelConstructor constructor(
     @SerialName("file_uuid")
     val fileUuid: String,
     @SerialName("file_info")
@@ -52,7 +53,7 @@ public data class MessageMedia(
  */
 @ApiModel
 @Serializable
-public data class SendMessageMedia(
+public data class SendMessageMedia @ApiModelConstructor constructor(
     // TODO
     @SerialName("file_info")
     val fileInfo: String,

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/PinsMessage.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/PinsMessage.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -20,6 +20,7 @@ package love.forte.simbot.qguild.model
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 
 
 /**
@@ -29,7 +30,7 @@ import love.forte.simbot.qguild.ApiModel
  */
 @Serializable
 @ApiModel
-public data class PinsMessage(
+public data class PinsMessage @ApiModelConstructor constructor(
     /**
      * 频道 id
      */

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/Role.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/Role.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -25,6 +25,16 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
+import love.forte.simbot.qguild.model.Role.Companion.DEFAULT_ID_ADMIN
+import love.forte.simbot.qguild.model.Role.Companion.DEFAULT_ID_ALL_MEMBER
+import love.forte.simbot.qguild.model.Role.Companion.DEFAULT_ID_CHANNEL_ADMIN
+import love.forte.simbot.qguild.model.Role.Companion.DEFAULT_ID_OWNER
+import love.forte.simbot.qguild.model.Role.Companion.DefaultAdmin
+import love.forte.simbot.qguild.model.Role.Companion.DefaultAllMember
+import love.forte.simbot.qguild.model.Role.Companion.DefaultChannelAdmin
+import love.forte.simbot.qguild.model.Role.Companion.DefaultOwner
+import love.forte.simbot.qguild.model.Role.Companion.isDefault
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
@@ -37,7 +47,7 @@ import kotlin.jvm.JvmStatic
  */
 @ApiModel
 @Serializable
-public data class Role(
+public data class Role @ApiModelConstructor constructor(
     /** 身份组ID */
     val id: String,
     /** 名称 */

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/Schedule.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/Schedule.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -20,7 +20,7 @@ package love.forte.simbot.qguild.model
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
-import love.forte.simbot.qguild.model.Schedule.RemindTypes
+import love.forte.simbot.qguild.ApiModelConstructor
 
 
 /**
@@ -32,7 +32,7 @@ import love.forte.simbot.qguild.model.Schedule.RemindTypes
  */
 @ApiModel
 @Serializable
-public data class Schedule(
+public data class Schedule @ApiModelConstructor constructor(
     /**
      * 日程 id
      */

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/User.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/User.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -20,6 +20,7 @@ package love.forte.simbot.qguild.model
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 
 /**
  * [用户对象](https://bot.q.qq.com/wiki/develop/api/openapi/user/model.html#user)
@@ -33,7 +34,7 @@ import love.forte.simbot.qguild.ApiModel
  */
 @ApiModel
 @Serializable
-public data class User(
+public data class User @ApiModelConstructor constructor(
     /** 用户 id */
     val id: String,
     /** 用户名 */

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/forum/AuditResult.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/forum/AuditResult.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -20,6 +20,7 @@ package love.forte.simbot.qguild.model.forum
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 
 /**
  *
@@ -31,7 +32,7 @@ import love.forte.simbot.qguild.ApiModel
  */
 @ApiModel
 @Serializable
-public data class AuditResult(
+public data class AuditResult @ApiModelConstructor constructor(
     /**
      * 频道ID
      */

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/forum/Post.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/forum/Post.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -20,6 +20,7 @@ package love.forte.simbot.qguild.model.forum
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 
 /**
  * 话题频道内对主题的评论称为帖子
@@ -31,7 +32,7 @@ import love.forte.simbot.qguild.ApiModel
  */
 @ApiModel
 @Serializable
-public data class Post(
+public data class Post @ApiModelConstructor constructor(
     /**
      * 频道ID
      */
@@ -64,7 +65,7 @@ public data class Post(
  */
 @ApiModel
 @Serializable
-public data class PostInfo(
+public data class PostInfo @ApiModelConstructor constructor(
     /**
      * 主题ID
      */

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/forum/Reply.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/forum/Reply.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -20,6 +20,7 @@ package love.forte.simbot.qguild.model.forum
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 
 /**
  * 话题频道对帖子回复或删除时生产该事件中包含该对象
@@ -32,7 +33,7 @@ import love.forte.simbot.qguild.ApiModel
  */
 @ApiModel
 @Serializable
-public data class Reply(
+public data class Reply @ApiModelConstructor constructor(
     /**
      * 频道ID
      */
@@ -66,7 +67,7 @@ public data class Reply(
  */
 @ApiModel
 @Serializable
-public data class ReplyInfo(
+public data class ReplyInfo @ApiModelConstructor constructor(
     /**
      * 主题ID
      */

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/forum/RichObject.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/forum/RichObject.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -20,6 +20,7 @@ package love.forte.simbot.qguild.model.forum
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 
 /**
  *
@@ -30,7 +31,7 @@ import love.forte.simbot.qguild.ApiModel
  */
 @ApiModel
 @Serializable
-public data class RichObject(
+public data class RichObject @ApiModelConstructor constructor(
     /**
      * 富文本类型
      *
@@ -117,7 +118,7 @@ public object RichTypes {
  */
 @ApiModel
 @Serializable
-public data class TextInfo(val text: String)
+public data class TextInfo @ApiModelConstructor constructor(val text: String)
 
 /**
  * 富文本 - @内容
@@ -127,7 +128,7 @@ public data class TextInfo(val text: String)
  */
 @ApiModel
 @Serializable
-public data class AtInfo(
+public data class AtInfo @ApiModelConstructor constructor(
     /**
      * at类型
      *
@@ -188,7 +189,7 @@ public object AtTypes {
  */
 @ApiModel
 @Serializable
-public data class AtUserInfo(
+public data class AtUserInfo @ApiModelConstructor constructor(
     /**
      * 身份组ID
      */
@@ -207,7 +208,7 @@ public data class AtUserInfo(
  */
 @ApiModel
 @Serializable
-public data class AtRoleInfo(
+public data class AtRoleInfo @ApiModelConstructor constructor(
     /**
      * 身份组ID
      */
@@ -230,7 +231,7 @@ public data class AtRoleInfo(
  */
 @ApiModel
 @Serializable
-public data class AtGuildInfo(
+public data class AtGuildInfo @ApiModelConstructor constructor(
     /**
      * 频道ID
      */
@@ -251,7 +252,7 @@ public data class AtGuildInfo(
  */
 @ApiModel
 @Serializable
-public data class URLInfo(
+public data class URLInfo @ApiModelConstructor constructor(
     /**
      * 链接地址
      */
@@ -272,7 +273,7 @@ public data class URLInfo(
  */
 @ApiModel
 @Serializable
-public data class EmojiInfo(
+public data class EmojiInfo @ApiModelConstructor constructor(
     /**
      * 表情id
      */
@@ -300,7 +301,7 @@ public data class EmojiInfo(
  */
 @ApiModel
 @Serializable
-public data class ChannelInfo(
+public data class ChannelInfo @ApiModelConstructor constructor(
     /**
      * 子频道id
      */
@@ -321,7 +322,7 @@ public data class ChannelInfo(
  */
 @ApiModel
 @Serializable
-public data class RichText(
+public data class RichText @ApiModelConstructor constructor(
     /**
      * 段落，一段落一行，段落内无元素的为空行
      */
@@ -336,7 +337,7 @@ public data class RichText(
  */
 @ApiModel
 @Serializable
-public data class Paragraph(
+public data class Paragraph @ApiModelConstructor constructor(
     /**
      * 元素列表
      */
@@ -355,7 +356,7 @@ public data class Paragraph(
  */
 @ApiModel
 @Serializable
-public data class Elem(
+public data class Elem @ApiModelConstructor constructor(
     /**
      * 文本元素
      */
@@ -415,7 +416,7 @@ public object ElemTypes {
  */
 @ApiModel
 @Serializable
-public data class TextElem(
+public data class TextElem @ApiModelConstructor constructor(
     /**
      * 正文
      */
@@ -436,7 +437,7 @@ public data class TextElem(
  */
 @ApiModel
 @Serializable
-public data class TextProps(
+public data class TextProps @ApiModelConstructor constructor(
     /**
      * 加粗
      */
@@ -460,7 +461,7 @@ public data class TextProps(
  */
 @ApiModel
 @Serializable
-public data class ImageElem(
+public data class ImageElem @ApiModelConstructor constructor(
     /**
      * 第三方图片链接
      */
@@ -481,7 +482,7 @@ public data class ImageElem(
  */
 @ApiModel
 @Serializable
-public data class PlatImage(
+public data class PlatImage @ApiModelConstructor constructor(
     /**
      * 架平图片链接
      */
@@ -510,7 +511,7 @@ public data class PlatImage(
  */
 @ApiModel
 @Serializable
-public data class VideoElem(
+public data class VideoElem @ApiModelConstructor constructor(
     /**
      * 第三方视频文件链接
      */
@@ -526,7 +527,7 @@ public data class VideoElem(
  */
 @ApiModel
 @Serializable
-public data class PlatVideo(
+public data class PlatVideo @ApiModelConstructor constructor(
     /**
      * 架平图片链接
      */
@@ -562,7 +563,7 @@ public data class PlatVideo(
  */
 @ApiModel
 @Serializable
-public data class URLElem(
+public data class URLElem @ApiModelConstructor constructor(
     /**
      * URL链接
      */
@@ -582,7 +583,7 @@ public data class URLElem(
  */
 @ApiModel
 @Serializable
-public data class ParagraphProps(
+public data class ParagraphProps @ApiModelConstructor constructor(
     /**
      * 段落对齐方向属性，数值可以参考 [Alignments]
      *

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/forum/Thread.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/forum/Thread.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -20,6 +20,7 @@ package love.forte.simbot.qguild.model.forum
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.qguild.ApiModel
+import love.forte.simbot.qguild.ApiModelConstructor
 
 /**
  *
@@ -33,7 +34,7 @@ import love.forte.simbot.qguild.ApiModel
  */
 @ApiModel
 @Serializable
-public data class Thread(
+public data class Thread @ApiModelConstructor constructor(
     /**
      * 频道ID
      */
@@ -65,7 +66,7 @@ public data class Thread(
  */
 @ApiModel
 @Serializable
-public data class ThreadInfo(
+public data class ThreadInfo @ApiModelConstructor constructor(
     /**
      * 主帖ID
      */

--- a/simbot-component-qq-guild-core/build.gradle.kts
+++ b/simbot-component-qq-guild-core/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025. ForteScarlet.
+ * Copyright (c) 2022-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -36,7 +36,10 @@ kotlin {
     applyDefaultHierarchyTemplate()
 
     compilerOptions {
-        optIn.add("love.forte.simbot.qguild.QGInternalApi")
+        optIn.addAll(
+            "love.forte.simbot.qguild.QGInternalApi",
+            "love.forte.simbot.qguild.ApiModelConstructor"
+        )
     }
 
     configKotlinJvm()

--- a/simbot-component-qq-guild-stdlib/build.gradle.kts
+++ b/simbot-component-qq-guild-stdlib/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025. ForteScarlet.
+ * Copyright (c) 2022-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -36,7 +36,10 @@ kotlin {
     applyDefaultHierarchyTemplate()
 
     compilerOptions {
-        optIn.add("love.forte.simbot.qguild.QGInternalApi")
+        optIn.addAll(
+            "love.forte.simbot.qguild.QGInternalApi",
+            "love.forte.simbot.qguild.ApiModelConstructor"
+        )
     }
 
     configKotlinJvm()


### PR DESCRIPTION
重构数据模型，添加 `@ApiModelConstructor` opt-in 注解，并调整相关配置以支持其使用，为所有 `@ApiModel` 标记的类型的构造函数增加此注解的标记来标注其兼容性问题。 