### PR TITLE
feat(api): 增加对多按钮信息 (`keyboards`) 的支持，并重构相关逻辑

### DIFF
--- a/simbot-component-qq-guild-api/api/simbot-component-qq-guild-api.api
+++ b/simbot-component-qq-guild-api/api/simbot-component-qq-guild-api.api
@@ -1642,12 +1642,13 @@ public class love/forte/simbot/qguild/api/message/GroupAndC2CSendBody {
 	public static final field MSG_TYPE_MARKDOWN I
 	public static final field MSG_TYPE_MEDIA I
 	public static final field MSG_TYPE_TEXT I
-	public synthetic fun <init> (ILjava/lang/String;ILlove/forte/simbot/qguild/model/Message$Markdown;Llove/forte/simbot/qguild/model/MessageKeyboard;Llove/forte/simbot/qguild/model/MessageMedia;Llove/forte/simbot/qguild/model/Message$Ark;Llove/forte/simbot/qguild/model/Message$Reference;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (ILjava/lang/String;ILlove/forte/simbot/qguild/model/Message$Markdown;Llove/forte/simbot/qguild/model/MessageKeyboards;Llove/forte/simbot/qguild/model/MessageMedia;Llove/forte/simbot/qguild/model/Message$Ark;Llove/forte/simbot/qguild/model/Message$Reference;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
 	public static final fun create (Ljava/lang/String;I)Llove/forte/simbot/qguild/api/message/GroupAndC2CSendBody;
 	public fun getArk ()Llove/forte/simbot/qguild/model/Message$Ark;
 	public fun getContent ()Ljava/lang/String;
 	public fun getEventId ()Ljava/lang/String;
 	public fun getKeyboard ()Llove/forte/simbot/qguild/model/MessageKeyboard;
+	public fun getKeyboards ()Llove/forte/simbot/qguild/model/MessageKeyboards;
 	public fun getMarkdown ()Llove/forte/simbot/qguild/model/Message$Markdown;
 	public fun getMedia ()Llove/forte/simbot/qguild/model/MessageMedia;
 	public fun getMessageReference ()Llove/forte/simbot/qguild/model/Message$Reference;
@@ -1658,6 +1659,7 @@ public class love/forte/simbot/qguild/api/message/GroupAndC2CSendBody {
 	public fun setContent (Ljava/lang/String;)V
 	public fun setEventId (Ljava/lang/String;)V
 	public fun setKeyboard (Llove/forte/simbot/qguild/model/MessageKeyboard;)V
+	public fun setKeyboards (Llove/forte/simbot/qguild/model/MessageKeyboards;)V
 	public fun setMarkdown (Llove/forte/simbot/qguild/model/Message$Markdown;)V
 	public fun setMedia (Llove/forte/simbot/qguild/model/MessageMedia;)V
 	public fun setMessageReference (Llove/forte/simbot/qguild/model/Message$Reference;)V
@@ -1829,6 +1831,7 @@ public final class love/forte/simbot/qguild/api/message/group/GroupMessageSendAp
 	public static final fun create (Ljava/lang/String;Llove/forte/simbot/qguild/api/message/GroupAndC2CSendBody;)Llove/forte/simbot/qguild/api/message/group/GroupMessageSendApi;
 	public static final fun createMarkdown (Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/qguild/api/message/group/GroupMessageSendApi;
 	public static final fun createMarkdown (Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/qguild/model/MessageKeyboard;)Llove/forte/simbot/qguild/api/message/group/GroupMessageSendApi;
+	public static final fun createMarkdown (Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/qguild/model/MessageKeyboards;)Llove/forte/simbot/qguild/api/message/group/GroupMessageSendApi;
 	public static final fun createText (Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/qguild/api/message/group/GroupMessageSendApi;
 	public fun getResultDeserializationStrategy ()Lkotlinx/serialization/DeserializationStrategy;
 }
@@ -1838,7 +1841,9 @@ public final class love/forte/simbot/qguild/api/message/group/GroupMessageSendAp
 	public final fun create (Ljava/lang/String;Llove/forte/simbot/qguild/api/message/GroupAndC2CSendBody;)Llove/forte/simbot/qguild/api/message/group/GroupMessageSendApi;
 	public final fun createMarkdown (Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/qguild/api/message/group/GroupMessageSendApi;
 	public final fun createMarkdown (Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/qguild/model/MessageKeyboard;)Llove/forte/simbot/qguild/api/message/group/GroupMessageSendApi;
+	public final fun createMarkdown (Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/qguild/model/MessageKeyboards;)Llove/forte/simbot/qguild/api/message/group/GroupMessageSendApi;
 	public static synthetic fun createMarkdown$default (Llove/forte/simbot/qguild/api/message/group/GroupMessageSendApi$Factory;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/qguild/model/MessageKeyboard;ILjava/lang/Object;)Llove/forte/simbot/qguild/api/message/group/GroupMessageSendApi;
+	public static synthetic fun createMarkdown$default (Llove/forte/simbot/qguild/api/message/group/GroupMessageSendApi$Factory;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/qguild/model/MessageKeyboards;ILjava/lang/Object;)Llove/forte/simbot/qguild/api/message/group/GroupMessageSendApi;
 	public final fun createText (Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/qguild/api/message/group/GroupMessageSendApi;
 }
 
@@ -1894,6 +1899,7 @@ public final class love/forte/simbot/qguild/api/message/user/UserMessageSendApi 
 	public static final fun create (Ljava/lang/String;Llove/forte/simbot/qguild/api/message/GroupAndC2CSendBody;)Llove/forte/simbot/qguild/api/message/user/UserMessageSendApi;
 	public static final fun createMarkdown (Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/qguild/api/message/user/UserMessageSendApi;
 	public static final fun createMarkdown (Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/qguild/model/MessageKeyboard;)Llove/forte/simbot/qguild/api/message/user/UserMessageSendApi;
+	public static final fun createMarkdown (Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/qguild/model/MessageKeyboards;)Llove/forte/simbot/qguild/api/message/user/UserMessageSendApi;
 	public static final fun createText (Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/qguild/api/message/user/UserMessageSendApi;
 	public fun getResultDeserializationStrategy ()Lkotlinx/serialization/DeserializationStrategy;
 }
@@ -1941,7 +1947,9 @@ public final class love/forte/simbot/qguild/api/message/user/UserMessageSendApi$
 	public final fun create (Ljava/lang/String;Llove/forte/simbot/qguild/api/message/GroupAndC2CSendBody;)Llove/forte/simbot/qguild/api/message/user/UserMessageSendApi;
 	public final fun createMarkdown (Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/qguild/api/message/user/UserMessageSendApi;
 	public final fun createMarkdown (Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/qguild/model/MessageKeyboard;)Llove/forte/simbot/qguild/api/message/user/UserMessageSendApi;
+	public final fun createMarkdown (Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/qguild/model/MessageKeyboards;)Llove/forte/simbot/qguild/api/message/user/UserMessageSendApi;
 	public static synthetic fun createMarkdown$default (Llove/forte/simbot/qguild/api/message/user/UserMessageSendApi$Factory;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/qguild/model/MessageKeyboard;ILjava/lang/Object;)Llove/forte/simbot/qguild/api/message/user/UserMessageSendApi;
+	public static synthetic fun createMarkdown$default (Llove/forte/simbot/qguild/api/message/user/UserMessageSendApi$Factory;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/qguild/model/MessageKeyboards;ILjava/lang/Object;)Llove/forte/simbot/qguild/api/message/user/UserMessageSendApi;
 	public final fun createText (Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/qguild/api/message/user/UserMessageSendApi;
 }
 
@@ -6089,7 +6097,7 @@ public final class love/forte/simbot/qguild/model/MessageKeyboard$Action {
 	public final fun component5 ()Ljava/lang/Integer;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()I
-	public final fun copy (Llove/forte/simbot/qguild/model/MessageKeyboard$ActionPermission;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;)Llove/forte/simbot/qguild/model/MessageKeyboard$Action;
+	public final synthetic fun copy (Llove/forte/simbot/qguild/model/MessageKeyboard$ActionPermission;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;)Llove/forte/simbot/qguild/model/MessageKeyboard$Action;
 	public static synthetic fun copy$default (Llove/forte/simbot/qguild/model/MessageKeyboard$Action;Llove/forte/simbot/qguild/model/MessageKeyboard$ActionPermission;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/qguild/model/MessageKeyboard$Action;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAnchor ()Ljava/lang/Integer;
@@ -6128,6 +6136,8 @@ public final class love/forte/simbot/qguild/model/MessageKeyboard$ActionPermissi
 	public final fun copy (ILjava/util/List;Ljava/util/List;)Llove/forte/simbot/qguild/model/MessageKeyboard$ActionPermission;
 	public static synthetic fun copy$default (Llove/forte/simbot/qguild/model/MessageKeyboard$ActionPermission;ILjava/util/List;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/qguild/model/MessageKeyboard$ActionPermission;
 	public fun equals (Ljava/lang/Object;)Z
+	public static final fun getAdminOnly ()Llove/forte/simbot/qguild/model/MessageKeyboard$ActionPermission;
+	public static final fun getAllAccessible ()Llove/forte/simbot/qguild/model/MessageKeyboard$ActionPermission;
 	public final fun getSpecifyRoleIds ()Ljava/util/List;
 	public final fun getSpecifyUserIds ()Ljava/util/List;
 	public final fun getType ()I
@@ -6147,6 +6157,8 @@ public synthetic class love/forte/simbot/qguild/model/MessageKeyboard$ActionPerm
 }
 
 public final class love/forte/simbot/qguild/model/MessageKeyboard$ActionPermission$Companion {
+	public final fun getAdminOnly ()Llove/forte/simbot/qguild/model/MessageKeyboard$ActionPermission;
+	public final fun getAllAccessible ()Llove/forte/simbot/qguild/model/MessageKeyboard$ActionPermission;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -6206,6 +6218,8 @@ public final class love/forte/simbot/qguild/model/MessageKeyboardActionBuilder {
 	public final fun getUnsupportTips ()Ljava/lang/String;
 	public final fun permission (Llove/forte/simbot/common/function/ConfigurerFunction;)Llove/forte/simbot/qguild/model/MessageKeyboardActionBuilder;
 	public final fun permission (Llove/forte/simbot/qguild/model/MessageKeyboard$ActionPermission;)Llove/forte/simbot/qguild/model/MessageKeyboardActionBuilder;
+	public final fun permissionAdminOnly ()Llove/forte/simbot/qguild/model/MessageKeyboardActionBuilder;
+	public final fun permissionAllAccessible ()Llove/forte/simbot/qguild/model/MessageKeyboardActionBuilder;
 	public final fun reply (Ljava/lang/Boolean;)Llove/forte/simbot/qguild/model/MessageKeyboardActionBuilder;
 	public final fun setAnchor (Ljava/lang/Integer;)V
 	public final fun setData (Ljava/lang/String;)V
@@ -6280,6 +6294,121 @@ public final class love/forte/simbot/qguild/model/MessageKeyboardRenderDataBuild
 	public final fun setVisitedLabel (Ljava/lang/String;)V
 	public final fun style (I)Llove/forte/simbot/qguild/model/MessageKeyboardRenderDataBuilder;
 	public final fun visitedLabel (Ljava/lang/String;)Llove/forte/simbot/qguild/model/MessageKeyboardRenderDataBuilder;
+}
+
+public final class love/forte/simbot/qguild/model/MessageKeyboards {
+	public static final field Companion Llove/forte/simbot/qguild/model/MessageKeyboards$Companion;
+	public static final fun builder ()Llove/forte/simbot/qguild/model/MessageKeyboardsBuilder;
+	public final fun component1 ()Llove/forte/simbot/qguild/model/MessageKeyboards$Content;
+	public static final fun create (Ljava/util/Collection;)Llove/forte/simbot/qguild/model/MessageKeyboards;
+	public static final fun create (Llove/forte/simbot/qguild/model/MessageKeyboard;)Llove/forte/simbot/qguild/model/MessageKeyboards;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Llove/forte/simbot/qguild/model/MessageKeyboards$Content;
+	public fun hashCode ()I
+	public static final fun parse (Ljava/lang/String;)Llove/forte/simbot/qguild/model/MessageKeyboards;
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/qguild/model/MessageKeyboards$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/qguild/model/MessageKeyboards$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/qguild/model/MessageKeyboards;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/qguild/model/MessageKeyboards;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/qguild/model/MessageKeyboards$Companion {
+	public final fun builder ()Llove/forte/simbot/qguild/model/MessageKeyboardsBuilder;
+	public final fun create (Ljava/util/Collection;)Llove/forte/simbot/qguild/model/MessageKeyboards;
+	public final fun create (Llove/forte/simbot/qguild/model/MessageKeyboard;)Llove/forte/simbot/qguild/model/MessageKeyboards;
+	public final fun parse (Ljava/lang/String;)Llove/forte/simbot/qguild/model/MessageKeyboards;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/qguild/model/MessageKeyboards$Content {
+	public static final field Companion Llove/forte/simbot/qguild/model/MessageKeyboards$Content$Companion;
+	public final fun component1 ()Ljava/util/List;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRows ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/qguild/model/MessageKeyboards$Content$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/qguild/model/MessageKeyboards$Content$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/qguild/model/MessageKeyboards$Content;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/qguild/model/MessageKeyboards$Content;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/qguild/model/MessageKeyboards$Content$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/qguild/model/MessageKeyboards$ContentRow {
+	public static final field Companion Llove/forte/simbot/qguild/model/MessageKeyboards$ContentRow$Companion;
+	public final fun component1 ()Ljava/util/List;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getButtons ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/qguild/model/MessageKeyboards$ContentRow$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/qguild/model/MessageKeyboards$ContentRow$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/qguild/model/MessageKeyboards$ContentRow;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/qguild/model/MessageKeyboards$ContentRow;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/qguild/model/MessageKeyboards$ContentRow$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/qguild/model/MessageKeyboardsBuilder {
+	public static final field Companion Llove/forte/simbot/qguild/model/MessageKeyboardsBuilder$Companion;
+	public fun <init> ()V
+	public final fun build ()Llove/forte/simbot/qguild/model/MessageKeyboards;
+	public final fun content (Lkotlin/jvm/functions/Function1;)Llove/forte/simbot/qguild/model/MessageKeyboardsBuilder;
+	public final fun content (Llove/forte/simbot/qguild/model/MessageKeyboards$Content;)Llove/forte/simbot/qguild/model/MessageKeyboardsBuilder;
+}
+
+public final class love/forte/simbot/qguild/model/MessageKeyboardsBuilder$Companion {
+}
+
+public final class love/forte/simbot/qguild/model/MessageKeyboardsBuilderKt {
+	public static final fun MessageKeyboards (Lkotlin/jvm/functions/Function1;)Llove/forte/simbot/qguild/model/MessageKeyboards;
+}
+
+public final class love/forte/simbot/qguild/model/MessageKeyboardsContentBuilder {
+	public fun <init> ()V
+	public final fun addRow (Llove/forte/simbot/qguild/model/MessageKeyboards$ContentRow;)Llove/forte/simbot/qguild/model/MessageKeyboardsContentBuilder;
+	public final fun addRows (Ljava/util/List;)Llove/forte/simbot/qguild/model/MessageKeyboardsContentBuilder;
+	public final fun addRows ([Llove/forte/simbot/qguild/model/MessageKeyboards$ContentRow;)Llove/forte/simbot/qguild/model/MessageKeyboardsContentBuilder;
+	public final fun build ()Llove/forte/simbot/qguild/model/MessageKeyboards$Content;
+	public final fun clearRows ()Llove/forte/simbot/qguild/model/MessageKeyboardsContentBuilder;
+	public final fun row (Lkotlin/jvm/functions/Function1;)Llove/forte/simbot/qguild/model/MessageKeyboardsContentBuilder;
+}
+
+public final class love/forte/simbot/qguild/model/MessageKeyboardsContentRowBuilder {
+	public fun <init> ()V
+	public final fun addButton (Llove/forte/simbot/qguild/model/MessageKeyboard;)Llove/forte/simbot/qguild/model/MessageKeyboardsContentRowBuilder;
+	public final fun addButtons (Ljava/util/List;)Llove/forte/simbot/qguild/model/MessageKeyboardsContentRowBuilder;
+	public final fun addButtons ([Llove/forte/simbot/qguild/model/MessageKeyboard;)Llove/forte/simbot/qguild/model/MessageKeyboardsContentRowBuilder;
+	public final fun build ()Llove/forte/simbot/qguild/model/MessageKeyboards$ContentRow;
+	public final fun button (Lkotlin/jvm/functions/Function1;)Llove/forte/simbot/qguild/model/MessageKeyboardsContentRowBuilder;
+	public final fun clearButtons ()Llove/forte/simbot/qguild/model/MessageKeyboardsContentRowBuilder;
 }
 
 public final class love/forte/simbot/qguild/model/MessageMedia {

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/ApiRequests.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/ApiRequests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024. ForteScarlet.
+ * Copyright (c) 2024-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/message/GroupAndC2CSendBody.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/message/GroupAndC2CSendBody.kt
@@ -36,7 +36,7 @@ import kotlin.jvm.JvmStatic
  * @property content 文本内容
  * @property msgType 消息类型： 0 文本，2 是 markdown，3 ark 消息，4 embed，7 media 富媒体
  * @property markdown
- * @property keyboard
+ * @property keyboards 消息按钮内容，会序列化为 `keyboard` 字段。
  * @property media
  * @property ark
  * @property messageReference
@@ -52,12 +52,28 @@ public open class GroupAndC2CSendBody internal constructor(
     public open var msgType: Int,
 ) {
     public open var markdown: Message.Markdown? = null
+
+    /**
+     * @since 4.4.0
+     */
     @SerialName("keyboard")
     public open var keyboards: MessageKeyboards? = null
 
-    // TODO 更好的兼容方式
-    @SerialName("_keyboard")
-    public open var keyboard: MessageKeyboard? = null
+    /**
+     * Deprecated: `MessageKeyboard` 的结构存在缺损，请直接使用 keyboards。
+     * 目前 keyboard 属性会直接读取或修改 [keyboards]:
+     * - setter 会直接覆盖设置为 [keyboards] 的第一个 row 的第一个 button。
+     * - getter 会尝试获取 [keyboards] 的第一个 row 的第一个 button。
+     */
+    @Deprecated(message = "`MessageKeyboard` 的结构存在缺损，请直接使用 keyboards。", level = DeprecationLevel.ERROR)
+    public open var keyboard: MessageKeyboard?
+        get() = keyboards?.content?.rows?.firstOrNull()?.buttons?.firstOrNull()
+        set(value) {
+            keyboards = value?.let { button ->
+                MessageKeyboards.create(button)
+            }
+        }
+
     public open var media: MessageMedia? = null
     public open var ark: Message.Ark? = null
 
@@ -100,7 +116,7 @@ public open class GroupAndC2CSendBody internal constructor(
     }
 
     override fun toString(): String {
-        return "GroupAndC2CSendBody(content='$content', msgType=$msgType, markdown=$markdown, keyboards=$keyboards, keyboard=$keyboard, media=$media, ark=$ark, messageReference=$messageReference, eventId=$eventId, msgId=$msgId, msgSeq=$msgSeq)"
+        return "GroupAndC2CSendBody(content='$content', msgType=$msgType, markdown=$markdown, keyboards=$keyboards, media=$media, ark=$ark, messageReference=$messageReference, eventId=$eventId, msgId=$msgId, msgSeq=$msgSeq)"
     }
 
 }
@@ -109,7 +125,7 @@ public open class GroupAndC2CSendBody internal constructor(
 public fun GroupAndC2CSendBody.isEmpty(): Boolean =
     content.isEmpty()
             && markdown == null
-            && keyboard == null
+            && keyboards == null
             && media == null
             && ark == null
             && messageReference == null

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/message/GroupAndC2CSendBody.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/message/GroupAndC2CSendBody.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024. ForteScarlet.
+ * Copyright (c) 2024-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -24,6 +24,7 @@ import love.forte.simbot.qguild.api.message.group.GroupMessageSendApi
 import love.forte.simbot.qguild.api.message.user.UserMessageSendApi
 import love.forte.simbot.qguild.model.Message
 import love.forte.simbot.qguild.model.MessageKeyboard
+import love.forte.simbot.qguild.model.MessageKeyboards
 import love.forte.simbot.qguild.model.MessageMedia
 import kotlin.jvm.JvmStatic
 
@@ -51,6 +52,11 @@ public open class GroupAndC2CSendBody internal constructor(
     public open var msgType: Int,
 ) {
     public open var markdown: Message.Markdown? = null
+    @SerialName("keyboard")
+    public open var keyboards: MessageKeyboards? = null
+
+    // TODO 更好的兼容方式
+    @SerialName("_keyboard")
     public open var keyboard: MessageKeyboard? = null
     public open var media: MessageMedia? = null
     public open var ark: Message.Ark? = null
@@ -94,8 +100,9 @@ public open class GroupAndC2CSendBody internal constructor(
     }
 
     override fun toString(): String {
-        return "GroupAndC2CSendBody(content='$content', msgType=$msgType, markdown=$markdown, keyboard=$keyboard, media=$media, ark=$ark, messageReference=$messageReference, eventId=$eventId, msgId=$msgId, msgSeq=$msgSeq)"
+        return "GroupAndC2CSendBody(content='$content', msgType=$msgType, markdown=$markdown, keyboards=$keyboards, keyboard=$keyboard, media=$media, ark=$ark, messageReference=$messageReference, eventId=$eventId, msgId=$msgId, msgSeq=$msgSeq)"
     }
+
 }
 
 @QGInternalApi

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/message/MessageSendApi.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/message/MessageSendApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024. ForteScarlet.
+ * Copyright (c) 2022-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -171,7 +171,6 @@ public class MessageSendApi private constructor(
      *
      */
     @Serializable
-    @ConsistentCopyVisibility
     public data class Body internal constructor(
         /**
          * 选填，消息内容，文本内容，支持[内嵌格式](https://bot.q.qq.com/wiki/develop/api/openapi/message/message_format.html)

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/message/group/GroupMessageSendApi.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/message/group/GroupMessageSendApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024. ForteScarlet.
+ * Copyright (c) 2024-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -23,6 +23,7 @@ import love.forte.simbot.qguild.api.PostQQGuildApi
 import love.forte.simbot.qguild.api.SimplePostApiDescription
 import love.forte.simbot.qguild.api.message.GroupAndC2CSendBody
 import love.forte.simbot.qguild.model.MessageKeyboard
+import love.forte.simbot.qguild.model.MessageKeyboards
 import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
 
@@ -77,18 +78,36 @@ public class GroupMessageSendApi private constructor(
          * @param markdown markdown消息内容
          */
         @JvmStatic
-        @JvmOverloads
+        @Deprecated("使用参数为 `MessageKeyboards` 的方法，而不是直接使用 `MessageKeyboard`")
         public fun createMarkdown(
             groupId: String,
             markdown: String,
             keyboard: MessageKeyboard? = null
-        ): GroupMessageSendApi =
-            create(
-                groupId,
-                GroupAndC2CSendBody.create(content = markdown, msgType = MSG_TYPE_MARKDOWN) {
-                    this.keyboard = keyboard
-                }
-            )
+        ): GroupMessageSendApi = create(
+            groupId,
+            GroupAndC2CSendBody.create(content = markdown, msgType = MSG_TYPE_MARKDOWN) {
+                this.keyboards = keyboard?.let { btn -> MessageKeyboards.create(btn) }
+            }
+        )
+
+        /**
+         * Create a [GroupMessageSendApi].
+         *
+         * @param markdown markdown消息内容
+         * @since 4.4.0
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun createMarkdown(
+            groupId: String,
+            markdown: String,
+            keyboards: MessageKeyboards? = null
+        ): GroupMessageSendApi = create(
+            groupId,
+            GroupAndC2CSendBody.create(content = markdown, msgType = MSG_TYPE_MARKDOWN) {
+                this.keyboards = keyboards
+            }
+        )
 
     }
 

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/message/user/UserMessageSendApi.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/api/message/user/UserMessageSendApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024. ForteScarlet.
+ * Copyright (c) 2024-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -27,6 +27,7 @@ import love.forte.simbot.qguild.api.message.GroupAndC2CSendBody
 import love.forte.simbot.qguild.api.message.IgnoreWhenUseFormData
 import love.forte.simbot.qguild.model.Message
 import love.forte.simbot.qguild.model.MessageKeyboard
+import love.forte.simbot.qguild.model.MessageKeyboards
 import love.forte.simbot.qguild.model.SendMessageMedia
 import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
@@ -93,21 +94,42 @@ public class UserMessageSendApi private constructor(
          * @param markdown markdown消息内容
          */
         @JvmStatic
-        @JvmOverloads
+        @Deprecated("使用带 `MessageKeyboards` 的方法，而不是直接使用 `MessageKeyboard`")
         public fun createMarkdown(
             openid: String,
             markdown: String,
             keyboard: MessageKeyboard? = null
-        ): UserMessageSendApi =
-            create(
-                openid,
-                GroupAndC2CSendBody.create(
-                    content = markdown,
-                    msgType = MSG_TYPE_MARKDOWN,
-                ) {
-                    this.keyboard = keyboard
-                }
-            )
+        ): UserMessageSendApi = create(
+            openid,
+            GroupAndC2CSendBody.create(
+                content = markdown,
+                msgType = MSG_TYPE_MARKDOWN,
+            ) {
+                this.keyboards = keyboard?.let { btn -> MessageKeyboards.create(btn) }
+            }
+        )
+
+        /**
+         * Create a [UserMessageSendApi].
+         *
+         * @param markdown markdown消息内容
+         * @since 4.4.0
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun createMarkdown(
+            openid: String,
+            markdown: String,
+            keyboards: MessageKeyboards? = null
+        ): UserMessageSendApi = create(
+            openid,
+            GroupAndC2CSendBody.create(
+                content = markdown,
+                msgType = MSG_TYPE_MARKDOWN,
+            ) {
+                this.keyboards = keyboards
+            }
+        )
     }
 
     override val resultDeserializationStrategy: DeserializationStrategy<UserMessageSendResult>

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/MessageKeyboard.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/MessageKeyboard.kt
@@ -25,9 +25,11 @@ import love.forte.simbot.qguild.QQGuild
 import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
 
-
 /**
  * [消息交互=>消息按钮](https://bot.q.qq.com/wiki/develop/api-v2/server-inter/message/trans/msg-btn.html)
+ *
+ * @see buildMessageKeyboard
+ * @see MessageKeyboards
  *
  * @author ForteScarlet
  */
@@ -113,13 +115,32 @@ public data class MessageKeyboard @ApiModelConstructor constructor(
          */
         @SerialName("specify_role_ids")
         val specifyRoleIds: List<String>? = null,
-    )
+    ) {
+        public companion object {
+            /**
+             * 一个 type = 1 的 [ActionPermission]，表示仅管理者可操作。
+             *
+             * @since 4.4.0
+             */
+            @JvmStatic
+            public val AdminOnly: ActionPermission = ActionPermission(type = 1)
+
+            /**
+             * 一个 type = 2 的 [ActionPermission]，表示所有人可访问。
+             *
+             * @since 4.4.0
+             */
+            @JvmStatic
+            public val AllAccessible: ActionPermission = ActionPermission(type = 2)
+
+        }
+
+    }
 
     /**
      * [MessageKeyboard.action].
      * 参考 [官方文档](https://bot.q.qq.com/wiki/develop/api-v2/server-inter/message/trans/msg-btn.html)
      */
-    @ConsistentCopyVisibility
     @ApiModel
     @Serializable
     public data class Action @ApiModelConstructor internal constructor(
@@ -182,6 +203,7 @@ public data class MessageKeyboard @ApiModelConstructor constructor(
         /**
          * 用于兼容截止到 4.2.2 版本的 data class copy 函数而使用的兼容性函数。
          */
+        @Deprecated(message = "用于二进制兼容的函数，不应直接使用", level = DeprecationLevel.HIDDEN)
         public fun copy(
             permission: ActionPermission? = this.permission,
             data: String? = this.data,

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/MessageKeyboardBuilder.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/MessageKeyboardBuilder.kt
@@ -44,6 +44,14 @@ public class MessageKeyboardBuilder(public var id: String? = null) {
     public var renderData: MessageKeyboard.RenderData? = null
     public var action: MessageKeyboard.Action? = null
 
+    private fun MessageKeyboard.RenderData.doCopy(): MessageKeyboard.RenderData = copy()
+    private fun MessageKeyboard.Action.doCopy(): MessageKeyboard.Action = copy(
+        permission = permission?.copy(
+            specifyUserIds = permission.specifyUserIds?.toList(),
+            specifyRoleIds = permission.specifyRoleIds?.toList()
+        )
+    )
+
     /**
      * 基于现有 [keyboard] 填充当前构建器。
      */
@@ -127,9 +135,12 @@ public class MessageKeyboardBuilder(public var id: String? = null) {
      * 构建 [MessageKeyboard]。
      */
     public fun build(): MessageKeyboard =
-        MessageKeyboard(id = id, renderData = renderData, action = action)
+        MessageKeyboard(id = id, renderData = renderData?.doCopy(), action = action?.doCopy())
 }
 
+/**
+ * 用于构建一个 [MessageKeyboard.RenderData] 对象。
+ */
 @MessageKeyboardBuilderDsl
 public class MessageKeyboardRenderDataBuilder {
     public lateinit var label: String
@@ -200,7 +211,10 @@ public class MessageKeyboardActionBuilder {
      * 基于现有 [action] 填充当前构建器。
      */
     public fun from(action: MessageKeyboard.Action): MessageKeyboardActionBuilder = also {
-        permission = action.permission
+        permission = action.permission?.copy(
+            specifyUserIds = action.permission.specifyUserIds,
+            specifyRoleIds = action.permission.specifyRoleIds
+        )
         data = action.data
         reply = action.reply
         enter = action.enter
@@ -214,6 +228,20 @@ public class MessageKeyboardActionBuilder {
      */
     public fun permission(permission: MessageKeyboard.ActionPermission?): MessageKeyboardActionBuilder = also {
         this.permission = permission
+    }
+
+    /**
+     * 设置操作权限为仅管理员可用。
+     */
+    public fun permissionAdminOnly(): MessageKeyboardActionBuilder = also {
+        this.permission = MessageKeyboard.ActionPermission.AdminOnly
+    }
+
+    /**
+     * 设置操作权限为仅所有人可用。
+     */
+    public fun permissionAllAccessible(): MessageKeyboardActionBuilder = also {
+        this.permission = MessageKeyboard.ActionPermission.AllAccessible
     }
 
     /**

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/MessageKeyboards.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/MessageKeyboards.kt
@@ -18,25 +18,73 @@
 package love.forte.simbot.qguild.model
 
 import kotlinx.serialization.Serializable
+import love.forte.simbot.qguild.QQGuild
+import love.forte.simbot.qguild.model.MessageKeyboards.Companion.builder
+import kotlin.jvm.JvmStatic
 
+public typealias MessageKeyboardButton = MessageKeyboard
 
 /**
  * [消息交互=>消息按钮](https://bot.q.qq.com/wiki/develop/api-v2/server-inter/message/trans/msg-btn.html)
  *
+ *
+ * Java 中可以通过 [builder] 构建实例；Kotlin 中还可以通过 DSL API 构建实例：
+ * ```Kotlin
+ * val keyboards = MessageKeyboards {
+ *     // this: MessageKeyboardsBuilder
+ *     // ...
+ * }
+ * ```
+ *
+ * @since 4.4.0
+ * @see MessageKeyboard
+ * @see MessageKeyboardsBuilder
+ *
  * @author ForteScarlet
  */
 @Serializable
-public data class MessageKeyboards(
-    val content: Content
-) {
+public data class MessageKeyboards internal constructor(val content: Content) {
+    /**
+     * 按钮内容，包含若干 [行][rows]。
+     */
     @Serializable
-    public data class Content(
-        public val rows: List<ContentRow>
-    )
+    public data class Content internal constructor(public val rows: List<ContentRow>)
 
+    /**
+     * 每行的内容，包含若干 [按钮][buttons]。
+     */
     @Serializable
-    public data class ContentRow(
-        val buttons: List<MessageKeyboard>
-    )
+    public data class ContentRow internal constructor(public val buttons: List<MessageKeyboardButton>)
 
+    public companion object {
+        /**
+         * 创建一个只有单行的 [消息按钮][MessageKeyboards]。
+         */
+        @JvmStatic
+        public fun create(singleRowButtons: Collection<MessageKeyboardButton>): MessageKeyboards =
+            MessageKeyboards(Content(listOf(ContentRow(singleRowButtons.toList()))))
+
+        /**
+         * 创建一个只有一个 [消息按钮][MessageKeyboards] 的 keyboard 对象。
+         */
+        @JvmStatic
+        public fun create(singleButton: MessageKeyboardButton): MessageKeyboards =
+            MessageKeyboards(Content(listOf(ContentRow(listOf(singleButton)))))
+
+        /**
+         * 将一个JSON字符串解析为 [MessageKeyboards] 对象。
+         */
+        @JvmStatic
+        public fun parse(jsonString: String): MessageKeyboards {
+            return QQGuild.DefaultJson.decodeFromString(serializer(), jsonString)
+        }
+
+        /**
+         * 获取一个 Builder。
+         */
+        @JvmStatic
+        public fun builder(): MessageKeyboardsBuilder {
+            return MessageKeyboardsBuilder()
+        }
+    }
 }

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/MessageKeyboards.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/MessageKeyboards.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024-2026. ForteScarlet.
+ *
+ * This file is part of simbot-component-qq-guild.
+ *
+ * simbot-component-qq-guild is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * simbot-component-qq-guild is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with simbot-component-qq-guild.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package love.forte.simbot.qguild.model
+
+import kotlinx.serialization.Serializable
+
+
+/**
+ * [消息交互=>消息按钮](https://bot.q.qq.com/wiki/develop/api-v2/server-inter/message/trans/msg-btn.html)
+ *
+ * @author ForteScarlet
+ */
+@Serializable
+public data class MessageKeyboards(
+    val content: Content
+) {
+    @Serializable
+    public data class Content(
+        public val rows: List<ContentRow>
+    )
+
+    @Serializable
+    public data class ContentRow(
+        val buttons: List<MessageKeyboard>
+    )
+
+}

--- a/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/MessageKeyboardsBuilder.kt
+++ b/simbot-component-qq-guild-api/src/commonMain/kotlin/love/forte/simbot/qguild/model/MessageKeyboardsBuilder.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026. ForteScarlet.
+ *
+ * This file is part of simbot-component-qq-guild.
+ *
+ * simbot-component-qq-guild is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * simbot-component-qq-guild is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with simbot-component-qq-guild.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package love.forte.simbot.qguild.model
+
+/**
+ * 通过 DSL 构建 [MessageKeyboards]。
+ *
+ * @since 4.4.0
+ */
+public inline fun MessageKeyboards(block: MessageKeyboardsBuilder.() -> Unit): MessageKeyboards =
+    MessageKeyboardsBuilder().also(block).build()
+
+@Retention(AnnotationRetention.BINARY)
+@DslMarker
+internal annotation class MessageKeyboardsBuilderDsl
+
+/**
+ * 用于更便捷构建 [MessageKeyboards] 的构建器，Java 中可用链式 API，Kotlin 额外提供一些 DSL API。
+ *
+ * @since 4.4.0
+ * @author ForteScarlet
+ */
+@MessageKeyboardsBuilderDsl
+public class MessageKeyboardsBuilder {
+    private var content: MessageKeyboards.Content = EMPTY_CONTENT
+
+    /**
+     * 直接设置 [MessageKeyboards.Content]。
+     */
+    public fun content(content: MessageKeyboards.Content): MessageKeyboardsBuilder = also {
+        this.content = content
+    }
+
+    /**
+     * 通过 DSL 构建并设置 [MessageKeyboards.Content]。
+     */
+    public fun content(builder: MessageKeyboardsContentBuilder.() -> Unit): MessageKeyboardsBuilder = also {
+        this.content = MessageKeyboardsContentBuilder().apply(builder).build()
+    }
+
+    /**
+     * 构建 [MessageKeyboards]。
+     */
+    public fun build(): MessageKeyboards = MessageKeyboards(content)
+
+    public companion object {
+        private val EMPTY_CONTENT = MessageKeyboards.Content(rows = emptyList())
+    }
+}
+
+/**
+ * 用于构建 [MessageKeyboards.Content] 的构建器。
+ *
+ * @since 4.4.0
+ * @author ForteScarlet
+ */
+@MessageKeyboardsBuilderDsl
+public class MessageKeyboardsContentBuilder {
+    private val rows = mutableListOf<MessageKeyboards.ContentRow>()
+
+    /**
+     * 添加一行按钮内容。
+     */
+    public fun addRow(contentRow: MessageKeyboards.ContentRow): MessageKeyboardsContentBuilder = also {
+        rows.add(contentRow)
+    }
+
+    /**
+     * 批量添加多行按钮内容。
+     */
+    public fun addRows(contentRows: List<MessageKeyboards.ContentRow>): MessageKeyboardsContentBuilder = also {
+        rows.addAll(contentRows)
+    }
+
+    /**
+     * 批量添加多行按钮内容。
+     */
+    public fun addRows(vararg contentRows: MessageKeyboards.ContentRow): MessageKeyboardsContentBuilder = also {
+        rows.addAll(contentRows)
+    }
+
+    /**
+     * 清空已添加的所有行。
+     */
+    public fun clearRows(): MessageKeyboardsContentBuilder = also {
+        rows.clear()
+    }
+
+    /**
+     * 通过 DSL 构建并添加一行按钮内容。
+     */
+    public fun row(builder: MessageKeyboardsContentRowBuilder.() -> Unit): MessageKeyboardsContentBuilder = also {
+        rows.add(MessageKeyboardsContentRowBuilder().apply(builder).build())
+    }
+
+    /**
+     * 构建 [MessageKeyboards.Content]。
+     */
+    public fun build(): MessageKeyboards.Content = MessageKeyboards.Content(rows = rows.toList())
+}
+
+/**
+ * 用于构建 [MessageKeyboards.ContentRow] 的构建器。
+ *
+ * @since 4.4.0
+ * @author ForteScarlet
+ */
+@MessageKeyboardsBuilderDsl
+public class MessageKeyboardsContentRowBuilder {
+    private val buttons = mutableListOf<MessageKeyboardButton>()
+
+    /**
+     * 添加一个按钮。
+     */
+    public fun addButton(button: MessageKeyboardButton): MessageKeyboardsContentRowBuilder = also {
+        buttons.add(button)
+    }
+
+    /**
+     * 批量添加多个按钮。
+     */
+    public fun addButtons(buttons: List<MessageKeyboardButton>): MessageKeyboardsContentRowBuilder = also {
+        this.buttons.addAll(buttons)
+    }
+
+    /**
+     * 批量添加多个按钮。
+     */
+    public fun addButtons(vararg buttons: MessageKeyboardButton): MessageKeyboardsContentRowBuilder = also {
+        this.buttons.addAll(buttons)
+    }
+
+    /**
+     * 清空已添加的所有按钮。
+     */
+    public fun clearButtons(): MessageKeyboardsContentRowBuilder = also {
+        buttons.clear()
+    }
+
+    /**
+     * 通过 DSL 构建并添加一个按钮。
+     */
+    public fun button(builder: MessageKeyboardBuilder.() -> Unit): MessageKeyboardsContentRowBuilder = also {
+        buttons.add(MessageKeyboardBuilder().apply(builder).build())
+    }
+
+    /**
+     * 构建 [MessageKeyboards.ContentRow]。
+     */
+    public fun build(): MessageKeyboards.ContentRow = MessageKeyboards.ContentRow(buttons = buttons.toList())
+}

--- a/simbot-component-qq-guild-api/src/commonTest/kotlin/MessageKeyboardsTest.kt
+++ b/simbot-component-qq-guild-api/src/commonTest/kotlin/MessageKeyboardsTest.kt
@@ -1,0 +1,133 @@
+package test
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import love.forte.simbot.qguild.QQGuild
+import love.forte.simbot.qguild.api.message.GroupAndC2CSendBody
+import love.forte.simbot.qguild.api.message.group.GroupMessageSendApi
+import love.forte.simbot.qguild.api.message.user.UserMessageSendApi
+import love.forte.simbot.qguild.model.MessageKeyboard
+import love.forte.simbot.qguild.model.MessageKeyboards
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class MessageKeyboardsTest {
+
+    @Test
+    fun dslBuildTest() {
+        val keyboards = MessageKeyboards {
+            content {
+                row {
+                    button {
+                        renderData("确认", visitedLabel = "已确认", style = 1)
+                        action {
+                            type = 1
+                            data = "confirm"
+                            unsupportTips = "当前客户端暂不支持"
+                            permissionAllAccessible()
+                        }
+                    }
+                }
+                row {
+                    addButton(MessageKeyboard.create("template-id"))
+                }
+            }
+        }
+
+        assertEquals(2, keyboards.content.rows.size)
+        assertEquals("确认", keyboards.content.rows[0].buttons.single().renderData?.label)
+        assertEquals("confirm", keyboards.content.rows[0].buttons.single().action?.data)
+        assertEquals(MessageKeyboard.ActionPermission.AllAccessible, keyboards.content.rows[0].buttons.single().action?.permission)
+        assertEquals("template-id", keyboards.content.rows[1].buttons.single().id)
+    }
+
+    @Test
+    fun parseMultiRowKeyboardTest() {
+        val keyboards = MessageKeyboards.parse(
+            """
+            {
+              "content": {
+                "rows": [
+                  {
+                    "buttons": [
+                      {
+                        "render_data": {
+                          "label": "确认",
+                          "visitedLabel": "已确认",
+                          "style": 1
+                        },
+                        "action": {
+                          "permission": {
+                            "type": 2
+                          },
+                          "data": "confirm",
+                          "reply": true,
+                          "enter": false,
+                          "anchor": 1,
+                          "unsupport_tips": "当前客户端暂不支持",
+                          "type": 1
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "buttons": [
+                      {
+                        "id": "template-id"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+            """.trimIndent()
+        )
+
+        assertEquals(2, keyboards.content.rows.size)
+        assertEquals("确认", keyboards.content.rows[0].buttons.single().renderData?.label)
+        assertEquals(MessageKeyboard.ActionPermission(type = 2), keyboards.content.rows[0].buttons.single().action?.permission)
+        assertEquals("template-id", keyboards.content.rows[1].buttons.single().id)
+    }
+
+    @Test
+    fun groupAndC2CBodySerializesKeyboardsAsKeyboardFieldTest() {
+        val body = GroupAndC2CSendBody.create("markdown", GroupAndC2CSendBody.MSG_TYPE_MARKDOWN) {
+            keyboards = MessageKeyboards.create(MessageKeyboard.create("template-id"))
+        }
+
+        val json = QQGuild.DefaultJson.encodeToString(body)
+        val tree = QQGuild.DefaultJson.parseToJsonElement(json).jsonObject
+
+        assertEquals(JsonPrimitive("markdown"), tree["content"])
+        assertEquals(JsonPrimitive(GroupAndC2CSendBody.MSG_TYPE_MARKDOWN), tree["msg_type"])
+        val keyboard = assertNotNull(tree["keyboard"] as? JsonObject)
+        assertEquals(
+            JsonPrimitive("template-id"),
+            keyboard["content"]?.jsonObject
+                ?.get("rows")?.jsonArray
+                ?.single()?.jsonObject
+                ?.get("buttons")?.jsonArray
+                ?.single()?.jsonObject
+                ?.get("id")
+        )
+    }
+
+    @Test
+    fun createMarkdownWithKeyboardsTest() {
+        val keyboards = MessageKeyboards.create(MessageKeyboard.create("template-id"))
+
+        val groupBody = GroupMessageSendApi
+            .createMarkdown("group-id", "markdown", keyboards)
+            .body as GroupAndC2CSendBody
+        val userBody = UserMessageSendApi
+            .createMarkdown("openid", "markdown", keyboards)
+            .body as GroupAndC2CSendBody
+
+        assertEquals("template-id", groupBody.keyboards?.content?.rows?.single()?.buttons?.single()?.id)
+        assertEquals("template-id", userBody.keyboards?.content?.rows?.single()?.buttons?.single()?.id)
+    }
+}

--- a/simbot-component-qq-guild-core/api/simbot-component-qq-guild-core.api
+++ b/simbot-component-qq-guild-core/api/simbot-component-qq-guild-core.api
@@ -2200,6 +2200,42 @@ public final class love/forte/simbot/component/qguild/message/QGKeyboard$Compani
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class love/forte/simbot/component/qguild/message/QGKeyboards : love/forte/simbot/component/qguild/message/QGMessageElement {
+	public static final field Companion Llove/forte/simbot/component/qguild/message/QGKeyboards$Companion;
+	public final fun component1 ()Llove/forte/simbot/qguild/model/MessageKeyboards;
+	public static final fun create (Ljava/util/Collection;)Llove/forte/simbot/component/qguild/message/QGKeyboards;
+	public static final fun create (Llove/forte/simbot/qguild/model/MessageKeyboard;)Llove/forte/simbot/component/qguild/message/QGKeyboards;
+	public static final fun create (Llove/forte/simbot/qguild/model/MessageKeyboards;)Llove/forte/simbot/component/qguild/message/QGKeyboards;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKeyboards ()Llove/forte/simbot/qguild/model/MessageKeyboards;
+	public fun hashCode ()I
+	public static final fun parse (Ljava/lang/String;)Llove/forte/simbot/component/qguild/message/QGKeyboards;
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/qguild/message/QGKeyboards$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/qguild/message/QGKeyboards$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/qguild/message/QGKeyboards;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/qguild/message/QGKeyboards;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/qguild/message/QGKeyboards$Companion {
+	public final fun create (Ljava/util/Collection;)Llove/forte/simbot/component/qguild/message/QGKeyboards;
+	public final fun create (Llove/forte/simbot/qguild/model/MessageKeyboard;)Llove/forte/simbot/component/qguild/message/QGKeyboards;
+	public final fun create (Llove/forte/simbot/qguild/model/MessageKeyboards;)Llove/forte/simbot/component/qguild/message/QGKeyboards;
+	public final fun parse (Ljava/lang/String;)Llove/forte/simbot/component/qguild/message/QGKeyboards;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/qguild/message/QGKeyboardsKt {
+	public static final fun QGKeyboards (Lkotlin/jvm/functions/Function1;)Llove/forte/simbot/component/qguild/message/QGKeyboards;
+}
+
 public final class love/forte/simbot/component/qguild/message/QGMarkdown : love/forte/simbot/component/qguild/message/QGMessageElement {
 	public static final field Companion Llove/forte/simbot/component/qguild/message/QGMarkdown$Companion;
 	public static final fun byMarkdown (Llove/forte/simbot/qguild/model/Message$Markdown;)Llove/forte/simbot/component/qguild/message/QGMarkdown;

--- a/simbot-component-qq-guild-core/build.gradle.kts
+++ b/simbot-component-qq-guild-core/build.gradle.kts
@@ -36,6 +36,7 @@ kotlin {
     applyDefaultHierarchyTemplate()
 
     compilerOptions {
+        freeCompilerArgs.add("-Xconsistent-data-class-copy-visibility")
         optIn.addAll(
             "love.forte.simbot.qguild.QGInternalApi",
             "love.forte.simbot.qguild.ApiModelConstructor"

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/message/QGArk.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/message/QGArk.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024. ForteScarlet.
+ * Copyright (c) 2022-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -37,7 +37,6 @@ import love.forte.simbot.message.Message as SimbotMessage
  */
 @SerialName("qg.ark")
 @Serializable
-@ConsistentCopyVisibility
 public data class QGArk internal constructor(
     @SerialName("template_id")
     public val templateId: ID,
@@ -93,6 +92,7 @@ internal object ArkParser : SendingMessageParser {
         else -> false
     }
 
+    @Suppress("RemoveRedundantQualifierName")
     override suspend fun invoke(
         index: Int,
         element: love.forte.simbot.message.Message.Element,

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/message/QGEmbed.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/message/QGEmbed.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024. ForteScarlet.
+ * Copyright (c) 2023-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -19,7 +19,6 @@ package love.forte.simbot.component.qguild.message
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import love.forte.simbot.event.MessageEvent
 import love.forte.simbot.message.Messages
 import love.forte.simbot.qguild.api.message.MessageSendApi
 import love.forte.simbot.qguild.message.EmbedBuilder
@@ -47,7 +46,6 @@ import kotlin.jvm.JvmStatic
  */
 @SerialName("qg.embed")
 @Serializable
-@ConsistentCopyVisibility
 public data class QGEmbed internal constructor(public val embed: Message.Embed) : QGMessageElement {
 
     public companion object {

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/message/QGKeyboard.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/message/QGKeyboard.kt
@@ -22,6 +22,7 @@ import love.forte.simbot.logger.LoggerFactory
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.Messages
 import love.forte.simbot.qguild.model.MessageKeyboard
+import love.forte.simbot.qguild.model.MessageKeyboards
 import kotlin.jvm.JvmStatic
 
 /**
@@ -29,10 +30,16 @@ import kotlin.jvm.JvmStatic
  * markdown 消息内含有的按钮信息
  *
  * @since 4.2.0
+ * @see QGKeyboards
  *
  * @author ForteScarlet
  */
 @Serializable
+@Deprecated(
+    "请使用 QGKeyboards，QGKeyboard 和原本的 MessageKeyboard 类型的结构不够完整。",
+    replaceWith = ReplaceWith("QGKeyboards", imports = ["love.forte.simbot.component.qguild.message.QGKeyboards"])
+)
+@Suppress("DEPRECATION")
 public data class QGKeyboard internal constructor(
     public val keyboard: MessageKeyboard
 ) : QGMessageElement {
@@ -50,11 +57,11 @@ public data class QGKeyboard internal constructor(
          * @see MessageKeyboard.create
          */
         @JvmStatic
-        public fun createById(id: String): QGKeyboard =
-            create(MessageKeyboard.create(id))
+        public fun createById(id: String): QGKeyboard = create(MessageKeyboard.create(id))
     }
 }
 
+@Suppress("DEPRECATION")
 internal object KeyboardParser : SendingMessageParser {
     internal val logger = LoggerFactory.getLogger("love.forte.simbot.component.qguild.message.KeyboardParser")
 
@@ -79,9 +86,9 @@ internal object KeyboardParser : SendingMessageParser {
         if (element is QGKeyboard) {
             val keyboard = element.keyboard
             val builder = builderContext.builderOrNew {
-                it.keyboard == null
+                it.keyboards == null
             }
-            builder.keyboard = keyboard
+            builder.keyboards = MessageKeyboards.create(keyboard)
         }
     }
 }

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/message/QGKeyboards.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/message/QGKeyboards.kt
@@ -21,8 +21,7 @@ import kotlinx.serialization.Serializable
 import love.forte.simbot.logger.LoggerFactory
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.Messages
-import love.forte.simbot.qguild.model.MessageKeyboard
-import kotlin.jvm.JvmStatic
+import love.forte.simbot.qguild.model.MessageKeyboards
 
 /**
  *
@@ -33,30 +32,13 @@ import kotlin.jvm.JvmStatic
  * @author ForteScarlet
  */
 @Serializable
-public data class QGKeyboard internal constructor(
-    public val keyboard: MessageKeyboard
+public data class QGKeyboards /* TODO internal */ constructor(
+    public val keyboards: MessageKeyboards
 ) : QGMessageElement {
-    public companion object {
-        /**
-         * 使用 [keyboard] 直接包装构建。
-         */
-        @JvmStatic
-        public fun create(keyboard: MessageKeyboard): QGKeyboard =
-            QGKeyboard(keyboard)
-
-        /**
-         * 使用 [id][MessageKeyboard.create] 构建。
-         *
-         * @see MessageKeyboard.create
-         */
-        @JvmStatic
-        public fun createById(id: String): QGKeyboard =
-            create(MessageKeyboard.create(id))
-    }
 }
 
-internal object KeyboardParser : SendingMessageParser {
-    internal val logger = LoggerFactory.getLogger("love.forte.simbot.component.qguild.message.KeyboardParser")
+internal object KeyboardsParser : SendingMessageParser {
+    internal val logger = LoggerFactory.getLogger("love.forte.simbot.component.qguild.message.KeyboardsParser")
 
     override suspend fun invoke(
         index: Int,
@@ -64,9 +46,9 @@ internal object KeyboardParser : SendingMessageParser {
         messages: Messages?,
         builderContext: SendingMessageParser.BuilderContext
     ) {
-        // 频道相关的消息发送不支持 keyboard
-        if (element is QGKeyboard) {
-            logger.warn("Keyboard message is not yet supported for sending to channel.")
+        // 频道相关的消息发送不支持 keyboards
+        if (element is QGKeyboards) {
+            logger.warn("Keyboards message is not yet supported for sending to channel.")
         }
     }
 
@@ -76,12 +58,12 @@ internal object KeyboardParser : SendingMessageParser {
         messages: Messages?,
         builderContext: SendingMessageParser.GroupAndC2CBuilderContext
     ) {
-        if (element is QGKeyboard) {
-            val keyboard = element.keyboard
+        if (element is QGKeyboards) {
+            val keyboards = element.keyboards
             val builder = builderContext.builderOrNew {
-                it.keyboard == null
+                it.keyboards == null
             }
-            builder.keyboard = keyboard
+            builder.keyboards = keyboards
         }
     }
 }

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/message/QGKeyboards.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/message/QGKeyboards.kt
@@ -21,20 +21,84 @@ import kotlinx.serialization.Serializable
 import love.forte.simbot.logger.LoggerFactory
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.Messages
+import love.forte.simbot.qguild.model.MessageKeyboardButton
 import love.forte.simbot.qguild.model.MessageKeyboards
+import love.forte.simbot.qguild.model.MessageKeyboardsBuilder
+import kotlin.jvm.JvmStatic
 
 /**
  *
- * markdown 消息内含有的按钮信息
+ * markdown 消息内含有的按钮信息。
  *
- * @since 4.2.0
+ * Kotlin 可以使用 DSL API 快速构建 [QGKeyboards] 对象实例：
+ * ```Kotlin
+ * QGKeyboards {
+ *   content {
+ *     // 第一行..
+ *     rows {
+ *       button { ... }
+ *       button { ... }
+ *     }
+ *     // 第二行..
+ *     rows {
+ *       button { ... }
+ *       button { ... }
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * @see QGKeyboards
+ *
+ * @since 4.4.0
  *
  * @author ForteScarlet
  */
 @Serializable
-public data class QGKeyboards /* TODO internal */ constructor(
-    public val keyboards: MessageKeyboards
-) : QGMessageElement {
+public data class QGKeyboards internal constructor(public val keyboards: MessageKeyboards) : QGMessageElement {
+
+    public companion object {
+        /**
+         * 使用 [keyboards] 直接包装构建。
+         *
+         * @see QGKeyboards
+         * @see MessageKeyboards.builder
+         */
+        @JvmStatic
+        public fun create(keyboards: MessageKeyboards): QGKeyboards = QGKeyboards(keyboards)
+
+        /**
+         * 使用 [singleButton] 直接包装构建一个单 button。
+         */
+        @JvmStatic
+        public fun create(singleButton: MessageKeyboardButton): QGKeyboards =
+            QGKeyboards(MessageKeyboards.create(singleButton))
+
+        /**
+         * 使用 [singleRowButtons] 直接包装构建一组单行 buttons。
+         */
+        @JvmStatic
+        public fun create(singleRowButtons: Collection<MessageKeyboardButton>): QGKeyboards =
+            QGKeyboards(MessageKeyboards.create(singleRowButtons))
+
+        /**
+         * 将一个JSON字符串解析为 [QGKeyboards] 对象。
+         */
+        @JvmStatic
+        public fun parse(jsonString: String): QGKeyboards {
+            return QGKeyboards(MessageKeyboards.parse(jsonString))
+        }
+
+    }
+}
+
+/**
+ * 构建 [QGKeyboards]。
+ *
+ * @since 4.4.0
+ */
+public inline fun QGKeyboards(builder: MessageKeyboardsBuilder.() -> Unit): QGKeyboards {
+    return QGKeyboards.create(MessageKeyboards { builder() })
 }
 
 internal object KeyboardsParser : SendingMessageParser {

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/message/QGMarkdown.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/message/QGMarkdown.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025. ForteScarlet.
+ * Copyright (c) 2024-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -33,7 +33,6 @@ import kotlin.jvm.JvmStatic
  * @author ForteScarlet
  */
 @Serializable
-@ConsistentCopyVisibility
 public data class QGMarkdown internal constructor(
     public val markdown: Message.Markdown
 ) : QGMessageElement {

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/message/SendingMessageParser.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/message/SendingMessageParser.kt
@@ -344,15 +344,14 @@ public object MessageParsers {
 
 }
 
+@TmfsDsl
 public class QGMessageForSendingForParse internal constructor() {
     public var sendBodyBuilder: MessageSendApi.Body.Builder = MessageSendApi.Body.Builder()
 
-    @TmfsDsl
     public inline fun forSending(block: MessageSendApi.Body.Builder.() -> Unit) {
         sendBodyBuilder.block()
     }
 
-    @TmfsDsl
     public fun contentAppend(contentText: String) {
         forSending {
             if (content == null) {
@@ -367,5 +366,5 @@ public class QGMessageForSendingForParse internal constructor() {
 
 @Retention(AnnotationRetention.BINARY)
 @DslMarker
-internal annotation class TmfsDsl // TencentMessageForSendingBuilderDsl
+internal annotation class TmfsDsl
 

--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/message/SendingMessageParser.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/message/SendingMessageParser.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025. ForteScarlet.
+ * Copyright (c) 2022-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -184,6 +184,7 @@ public object MessageParsers {
         add(MediaParser)
         add(MarkdownParser)
         add(KeyboardParser)
+        add(KeyboardsParser)
     }
 
     @ExperimentalQGApi

--- a/simbot-component-qq-guild-core/src/commonTest/kotlin/love/forte/simbot/component/qgguild/test/MessageParserTests.kt
+++ b/simbot-component-qq-guild-core/src/commonTest/kotlin/love/forte/simbot/component/qgguild/test/MessageParserTests.kt
@@ -7,13 +7,11 @@ import love.forte.simbot.component.qguild.ExperimentalQGApi
 import love.forte.simbot.component.qguild.QQGuildComponent
 import love.forte.simbot.component.qguild.bot.config.QGBotComponentConfiguration
 import love.forte.simbot.component.qguild.internal.bot.QGBotImpl
-import love.forte.simbot.component.qguild.message.MessageParsers
-import love.forte.simbot.component.qguild.message.QGKeyboard
-import love.forte.simbot.component.qguild.message.QGMarkdown
-import love.forte.simbot.component.qguild.message.SendingMessageParser
+import love.forte.simbot.component.qguild.message.*
 import love.forte.simbot.event.*
 import love.forte.simbot.message.plus
 import love.forte.simbot.qguild.api.message.GroupAndC2CSendBody
+import love.forte.simbot.qguild.model.MessageKeyboard
 import love.forte.simbot.qguild.stdlib.BotFactory
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -71,7 +69,65 @@ class MessageParserTests {
 
         assertEquals(1, bodies.size)
         assertEquals("content", bodies.first().markdown?.content)
-        assertEquals("1", bodies.first().keyboard?.id)
+        assertEquals("1", bodies.first().keyboards?.content?.rows?.single()?.buttons?.single()?.id)
+    }
+
+    @OptIn(ExperimentalQGApi::class)
+    @Test
+    fun testKeyboardsParse() = runTest {
+        val keyboards = QGKeyboards {
+            content {
+                row {
+                    button {
+                        renderData("A")
+                        action(data = "a", unsupportTips = "unsupported")
+                    }
+                }
+                row {
+                    addButton(MessageKeyboard.create("template-id"))
+                }
+            }
+        }
+
+        val bot = QGBotImpl(
+            BotFactory.create("", "", ""),
+            QQGuildComponent(),
+            object : EventDispatcher {
+                override fun push(event: Event): Flow<EventResult> {
+                    TODO("Not yet implemented")
+                }
+
+                override fun dispose(listener: EventListener) {
+                    TODO("Not yet implemented")
+                }
+
+                override fun register(
+                    propertiesConsumer: ConfigurerFunction<EventListenerRegistrationProperties>?,
+                    listener: EventListener
+                ): EventListenerRegistrationHandle {
+                    TODO("Not yet implemented")
+                }
+
+                override val listeners: Sequence<EventListener>
+                    get() = TODO("Not yet implemented")
+            },
+            QGBotComponentConfiguration()
+        )
+
+        val bodies = MessageParsers.parseToGroupAndC2C(
+            bot = bot,
+            message = QGMarkdown.create("content") + keyboards,
+            builderType = SendingMessageParser.GroupBuilderType.GROUP,
+            targetOpenid = "123",
+            factory = {
+                GroupAndC2CSendBody.create("", GroupAndC2CSendBody.MSG_TYPE_MARKDOWN)
+            }
+        )
+
+        val body = bodies.single()
+        assertEquals("content", body.markdown?.content)
+        assertEquals("A", body.keyboards?.content?.rows?.get(0)?.buttons?.single()?.renderData?.label)
+        assertEquals("template-id", body.keyboards?.content?.rows?.get(1)?.buttons?.single()?.id)
     }
 
 }

--- a/simbot-component-qq-guild-core/src/commonTest/kotlin/love/forte/simbot/component/qgguild/test/QGBotTests.kt
+++ b/simbot-component-qq-guild-core/src/commonTest/kotlin/love/forte/simbot/component/qgguild/test/QGBotTests.kt
@@ -140,6 +140,6 @@ class QGBotTests {
         // Verify the parsed message
         assertEquals(1, bodies.size)
         assertEquals("# Hello", bodies.first().markdown?.content)
-        assertEquals("123", bodies.first().keyboard?.id)
+        assertEquals("123", bodies.first().keyboards?.content?.rows?.single()?.buttons?.single()?.id)
     }
 }


### PR DESCRIPTION
在 API 中引入了对多种按钮结构（`keyboards`）的支持，实现了 `MessageKeyboards` 类型以取代之前的 `MessageKeyboard` 类型。

过去的 `MessageKeyboard` 结构有所缺损，因此导致直接发送实际上是无法使用的。现在的 `MessageKeyboard` 转变为 `MessageKeyboards` 内部 `content.rows[*].buttons[*]` 中的元素对象结构了。