### PR TITLE
fix(message): 改进/修复内嵌消息解析与处理逻辑，不再仅处理纯数字ID

### DIFF
--- a/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/message/StandardMessageParsers.kt
+++ b/simbot-component-qq-guild-core/src/commonMain/kotlin/love/forte/simbot/component/qguild/message/StandardMessageParsers.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024. ForteScarlet.
+ * Copyright (c) 2022-2026. ForteScarlet.
  *
  * This file is part of simbot-component-qq-guild.
  *
@@ -144,16 +144,16 @@ internal object QGMessageParser : ReceivingMessageParser {
                 "|<#(?<$MENTION_CHANNEL_VALUE>\\d+)>" +
                 "|<emoji:(?<$EMOJI_VALUE>\\d+)>" +
                 // 兼容之前的两个写法解析
-                "|<@!?(?<$AT_USER_OLD_VALUE>\\d+)>" +
+                "|<@!?(?<$AT_USER_OLD_VALUE>[.a-zA-Z0-9_-]+)>" +
                 "|(?<$AT_EVERYONE_OLD_GROUP>@everyone)"
     )
 
     private val replaceWithoutMentionAllRegex = Regex(
-        "<qqbot-at-user +id=\"(?<$AT_USER_VALUE>[.a-zA-Z0-9_-]+)\" */>" +
+        "<qqbot-at-user +id=\"(?<$AT_USER_VALUE>[a-zA-Z0-9_-]+)\" */>" +
                 "|<#(?<$MENTION_CHANNEL_VALUE>\\d+)>" +
                 "|<emoji:(?<$EMOJI_VALUE>\\d+)>" +
                 // 兼容之前的两个写法解析
-                "|<@!?(?<$AT_USER_OLD_VALUE>\\d+)>"
+                "|<@!?(?<$AT_USER_OLD_VALUE>[.a-zA-Z0-9_-]+)>"
     )
 
     override fun invoke(qgContent: String, context: ReceivingMessageParser.Context): ReceivingMessageParser.Context {

--- a/simbot-component-qq-guild-core/src/commonTest/kotlin/love/forte/simbot/component/qgguild/test/MessageParserTests.kt
+++ b/simbot-component-qq-guild-core/src/commonTest/kotlin/love/forte/simbot/component/qgguild/test/MessageParserTests.kt
@@ -3,24 +3,45 @@ package love.forte.simbot.component.qgguild.test
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.test.runTest
 import love.forte.simbot.common.function.ConfigurerFunction
+import love.forte.simbot.common.id.literal
 import love.forte.simbot.component.qguild.ExperimentalQGApi
 import love.forte.simbot.component.qguild.QQGuildComponent
 import love.forte.simbot.component.qguild.bot.config.QGBotComponentConfiguration
 import love.forte.simbot.component.qguild.internal.bot.QGBotImpl
 import love.forte.simbot.component.qguild.message.*
 import love.forte.simbot.event.*
+import love.forte.simbot.message.At
 import love.forte.simbot.message.plus
 import love.forte.simbot.qguild.api.message.GroupAndC2CSendBody
 import love.forte.simbot.qguild.model.MessageKeyboard
 import love.forte.simbot.qguild.stdlib.BotFactory
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 
 /**
  *
  * @author ForteScarlet
  */
 class MessageParserTests {
+    @Test
+    fun testReceiveNonNumericUserMentions() {
+        val oldFormat = MessageParsers.parse("<@2F61FF438B355A8CB1A1874C187C2F87>签到")
+        assertEquals("签到", oldFormat.plainTextBuilder.toString())
+        assertEquals("2F61FF438B355A8CB1A1874C187C2F87", assertIs<At>(oldFormat.messages.first()).target.literal)
+
+        val cases = listOf(
+            "<@!abc.DEF_ghi-jkl>" to "abc.DEF_ghi-jkl",
+            "<@123456>" to "123456",
+            "<qqbot-at-user id=\"abc.DEF_ghi-jkl\" />" to "abc.DEF_ghi-jkl",
+        )
+        cases.forEach { (content, expectedId) ->
+            val context = MessageParsers.parse(content)
+            assertEquals("", context.plainTextBuilder.toString())
+            assertEquals(expectedId, assertIs<At>(context.messages.single()).target.literal)
+        }
+    }
+
     @OptIn(ExperimentalQGApi::class)
     @Test
     fun testKeyboardParse() = runTest {


### PR DESCRIPTION
可以解析例如 `<@2F61FF438B355A8CB1A1874C187C2F87>签到` 这样的消息，并且让纯文本消息只留下 `签到`。 